### PR TITLE
Fix missing reservedCellAttributes Set lost in zoom merge

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -413,6 +413,11 @@ class GameGrid implements IGameGrid {
     ]);
 
     cell.style.width = `${100 / colCount}%`;
+    const reservedCellAttributes = new Set([
+      'data-gamegrid-ref',
+      'data-gamegrid-coords',
+      'data-gamegrid-cell-type',
+    ]);
     cellData.cellAttributes?.forEach((attr: string[]) => {
       if (reservedCellAttributes.has(attr[0])) {
         return;


### PR DESCRIPTION
## Summary
- Restores the `reservedCellAttributes` `Set` in `renderCell` that was dropped when zoom support merged with the cell-attribute hardening from #43.
- Without it, `render()` throws `ReferenceError`, `tsc` fails, GitHub Pages CI fails, and 67 DOM-related tests break.

## Test plan
- [x] `npm run build.safe` (142/142 tests pass, build succeeds)
- [ ] GitHub Pages workflow passes on merge


Made with [Cursor](https://cursor.com)