### PR TITLE
Add .npmrc.example for npm publish setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@ demo/dist
 dist
 coverage
 coverage/
+.npmrc
+.env
 
 # Generated site payloads (landing page at gh-pages/* is tracked)
 /gh-pages/docs/

--- a/.npmrc.example
+++ b/.npmrc.example
@@ -1,0 +1,13 @@
+# Copy to .npmrc (gitignored) for publishing @tamb/gamegrid.
+# Do not commit real tokens.
+
+registry=https://registry.npmjs.org/
+
+# Required when publishing scoped packages to the public npm registry.
+access=public
+
+# Create a token at https://www.npmjs.com/settings/~/tokens
+# (Automation for CI, or Granular Access with publish permission).
+//registry.npmjs.org/:_authToken=${NPM_TOKEN}
+
+# Local alternative: run `npm login` and omit the _authToken line above.


### PR DESCRIPTION
## Summary
- Adds [`.npmrc.example`](.npmrc.example) documenting registry, `access=public` for `@tamb/gamegrid`, and `${NPM_TOKEN}` auth for publish/CI.
- Gitignores `.npmrc` and `.env` so local tokens and secrets are not committed.

## Test plan
- [x] Confirm `.npmrc` is not tracked (`git status` clean after local copy)
- [ ] Copy example to `.npmrc`, set `NPM_TOKEN`, run `npm run safe.publish -- --dry-run` (optional)


Made with [Cursor](https://cursor.com)