### PR TITLE
Fix demo builds when dist/ is missing

### DIFF
--- a/demo/src/partials/bigmaze.hbs
+++ b/demo/src/partials/bigmaze.hbs
@@ -14,7 +14,7 @@
     </div>
     <div class='col-12 col-xl-5 order-1 order-xl-2'>
       <div class='demo-grid-wrap demo-grid-wrap--tall mx-auto'>
-        <div id='maze'></div>
+        <div class='demo-grid-mount' id='maze'></div>
         {{> touchpad id="bigmaze-demo-dpad"}}
       </div>
     </div>

--- a/demo/src/partials/coinmaze.hbs
+++ b/demo/src/partials/coinmaze.hbs
@@ -25,7 +25,7 @@
     </div>
     <div class='col-12 col-xl-4 order-1 order-xl-2'>
       <div class='demo-grid-wrap mx-auto'>
-        <div id='maze3'></div>
+        <div class='demo-grid-mount' id='maze3'></div>
         {{> touchpad id="coin-demo-dpad"}}
       </div>
     </div>

--- a/demo/src/partials/events.hbs
+++ b/demo/src/partials/events.hbs
@@ -2,7 +2,7 @@
   <div class='row g-3'>
     <div class='col-12 col-lg-5 col-xl-4'>
       <div class='demo-grid-wrap mx-auto'>
-        <div id='grid1'></div>
+        <div class='demo-grid-mount' id='grid1'></div>
         {{> touchpad id="events-demo-dpad"}}
       </div>
     </div>
@@ -10,7 +10,7 @@
       <div>
         <h2>Events</h2>
         <p class='text-muted small mb-2 d-xl-none'>
-          Use the directional pad below the grid to move on touch devices.
+          Use the directional pads beside the grid to move on touch devices.
         </p>
         <div id='move-events'>
           <ul></ul>

--- a/demo/src/partials/minimaze.hbs
+++ b/demo/src/partials/minimaze.hbs
@@ -20,7 +20,7 @@
     </div>
     <div class='col-12 col-xl-5 order-1 order-xl-2'>
       <div class='demo-grid-wrap mx-auto'>
-        <div id='maze2'></div>
+        <div class='demo-grid-mount' id='maze2'></div>
         {{> touchpad id="minimaze-demo-dpad"}}
       </div>
     </div>

--- a/demo/src/partials/mobilecomponent.hbs
+++ b/demo/src/partials/mobilecomponent.hbs
@@ -3,8 +3,8 @@
     <div class='col-12 col-xl-7 order-2 order-xl-1'>
       <h2>Mobile Component</h2>
       <p>
-        Move around the grid with WASD / arrow keys, or use the directional pad
-        below the grid on touch-sized viewports.
+        Move around the grid with WASD / arrow keys, or use the directional pads
+        beside the grid on touch-sized viewports.
       </p>
       <p>
         The grid logs move details to the browser console when you land on a
@@ -13,7 +13,7 @@
     </div>
     <div class='col-12 col-xl-5 order-1 order-xl-2'>
       <div class='demo-grid-wrap mx-auto'>
-        <div id='mobile-component-grid'></div>
+        <div class='demo-grid-mount' id='mobile-component-grid'></div>
         {{> touchpad id="mobile-demo-dpad"}}
       </div>
     </div>

--- a/demo/src/partials/touchpad.hbs
+++ b/demo/src/partials/touchpad.hbs
@@ -1,38 +1,30 @@
 <div
   id='{{id}}'
-  class='gamegrid-touch-controls d-xl-none mt-3'
+  class='gamegrid-touch-controls d-xl-none'
   aria-label='On-screen movement controls'
 >
-  <div class='gamegrid-dpad' role='group' aria-label='Move in the grid'>
-    <div class='gamegrid-dpad-row gamegrid-dpad-row--up'>
-      <button
-        type='button'
-        class='btn btn-outline-primary gamegrid-dpad-btn'
-        data-gamegrid-move='up'
-        aria-label='Move up'
-      >↑</button>
-    </div>
-    <div class='gamegrid-dpad-row gamegrid-dpad-row--mid'>
-      <button
-        type='button'
-        class='btn btn-outline-primary gamegrid-dpad-btn'
-        data-gamegrid-move='left'
-        aria-label='Move left'
-      >←</button>
-      <button
-        type='button'
-        class='btn btn-outline-primary gamegrid-dpad-btn'
-        data-gamegrid-move='right'
-        aria-label='Move right'
-      >→</button>
-    </div>
-    <div class='gamegrid-dpad-row gamegrid-dpad-row--down'>
-      <button
-        type='button'
-        class='btn btn-outline-primary gamegrid-dpad-btn'
-        data-gamegrid-move='down'
-        aria-label='Move down'
-      >↓</button>
-    </div>
-  </div>
+  <button
+    type='button'
+    class='btn btn-outline-primary gamegrid-dpad-btn gamegrid-dpad-btn--up'
+    data-gamegrid-move='up'
+    aria-label='Move up'
+  >↑</button>
+  <button
+    type='button'
+    class='btn btn-outline-primary gamegrid-dpad-btn gamegrid-dpad-btn--left'
+    data-gamegrid-move='left'
+    aria-label='Move left'
+  >←</button>
+  <button
+    type='button'
+    class='btn btn-outline-primary gamegrid-dpad-btn gamegrid-dpad-btn--right'
+    data-gamegrid-move='right'
+    aria-label='Move right'
+  >→</button>
+  <button
+    type='button'
+    class='btn btn-outline-primary gamegrid-dpad-btn gamegrid-dpad-btn--down'
+    data-gamegrid-move='down'
+    aria-label='Move down'
+  >↓</button>
 </div>

--- a/demo/src/partials/zoommaze.hbs
+++ b/demo/src/partials/zoommaze.hbs
@@ -31,7 +31,7 @@
     </div>
     <div class='col-12 col-xl-5 order-1 order-xl-2'>
       <div class='demo-grid-wrap demo-grid-wrap--zoom mx-auto'>
-        <div id='zoom-maze'></div>
+        <div class='demo-grid-mount' id='zoom-maze'></div>
         {{> touchpad id="zoommaze-demo-dpad"}}
       </div>
     </div>

--- a/demo/src/styles/styles.scss
+++ b/demo/src/styles/styles.scss
@@ -120,6 +120,57 @@
   overflow: auto;
 }
 
+/* Mobile: anchor d-pad arrows to the outer edges of the grid */
+@media (max-width: 1199.98px) {
+  .demo-grid-wrap {
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr) auto;
+    grid-template-rows: auto minmax(0, 1fr) auto;
+    grid-template-areas:
+      '. up .'
+      'left grid right'
+      '. down .';
+    gap: 0.25rem;
+    align-items: stretch;
+    justify-items: stretch;
+    max-width: min(calc(100% - 0.5rem), 460px);
+    overflow: visible;
+  }
+
+  .demo-grid-wrap--tall {
+    max-width: min(calc(100% - 0.5rem), 480px);
+    max-height: min(62vh, 580px);
+    overflow: visible;
+  }
+
+  .demo-grid-wrap--zoom {
+    max-width: min(calc(100% - 0.5rem), 260px);
+    max-height: min(40vh, 260px);
+    overflow: visible;
+  }
+
+  .demo-grid-wrap > .demo-grid-mount {
+    grid-area: grid;
+    width: 100%;
+    min-width: 0;
+    min-height: 0;
+    overflow: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  .demo-grid-wrap--tall > .demo-grid-mount {
+    max-height: min(62vh, 580px);
+  }
+
+  .demo-grid-wrap--zoom > .demo-grid-mount {
+    max-height: min(40vh, 260px);
+  }
+
+  .demo-grid-wrap .gamegrid-touch-controls {
+    display: contents;
+  }
+}
+
 $zoom-quadrant-nw: #93c5fd;
 $zoom-quadrant-ne: #86efac;
 $zoom-quadrant-sw: #fcd34d;
@@ -179,33 +230,43 @@ $zoom-quadrant-se: #f9a8d4;
 .gamegrid-touch-controls {
   touch-action: manipulation;
   -webkit-tap-highlight-color: transparent;
-}
-
-.gamegrid-dpad {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 0.35rem;
   user-select: none;
 }
 
-.gamegrid-dpad-row--mid {
-  display: flex;
-  flex-direction: row;
-  gap: 0.75rem;
-  justify-content: center;
-  align-items: center;
-}
-
 .gamegrid-dpad-btn {
-  min-width: 3.25rem;
-  min-height: 3rem;
+  min-width: 2.75rem;
+  min-height: 2.75rem;
   font-size: 1.25rem;
   line-height: 1;
-  padding: 0.35rem 0.65rem;
+  padding: 0.35rem 0.5rem;
 }
 
-.gamegrid-dpad-row--up .gamegrid-dpad-btn,
-.gamegrid-dpad-row--down .gamegrid-dpad-btn {
-  min-width: 4.5rem;
+@media (max-width: 1199.98px) {
+  .gamegrid-dpad-btn--up {
+    grid-area: up;
+    justify-self: stretch;
+    width: 100%;
+    min-height: 2.75rem;
+  }
+
+  .gamegrid-dpad-btn--left {
+    grid-area: left;
+    align-self: stretch;
+    height: 100%;
+    min-width: 2.75rem;
+  }
+
+  .gamegrid-dpad-btn--right {
+    grid-area: right;
+    align-self: stretch;
+    height: 100%;
+    min-width: 2.75rem;
+  }
+
+  .gamegrid-dpad-btn--down {
+    grid-area: down;
+    justify-self: stretch;
+    width: 100%;
+    min-height: 2.75rem;
+  }
 }

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0-rc.0",
   "description": "",
   "main": "dist/main.js",
+  "source": "src/index.ts",
   "types": "dist/index.d.ts",
   "files": [
     "dist/**/*"

--- a/src/__tests__/package-manifest.test.ts
+++ b/src/__tests__/package-manifest.test.ts
@@ -1,0 +1,12 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+describe('package manifest', () => {
+  it('exposes a source entry so the Parcel demo can bundle without a prebuilt dist/', () => {
+    const pkg = JSON.parse(
+      readFileSync(resolve(import.meta.dirname, '../../package.json'), 'utf8'),
+    ) as { source?: string };
+
+    expect(pkg.source).toBe('src/index.ts');
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The Parcel demo resolves `@tamb/gamegrid` through `package.json#main` (`dist/main.js`). After `npm run demo:clean`, a fresh clone, or any workflow that removes `dist/` before starting Parcel, the demo fails to build with:

```
Failed to resolve '@tamb/gamegrid'
Could not load './dist/main.js' ... does not exist
```

On mobile, the on-screen directional pad also sat below the grid instead of along its edges, making edge taps awkward.

## Root cause

Library packaging issue for the build failure (demo depended on a prebuilt `dist/`). Parcel supports compiling symlinked/workspace packages from source when a `source` entry is provided.

## Fix

- Add `"source": "src/index.ts"` to the library `package.json` so Parcel bundles the demo from source when the package is linked via `file:..`.
- Add a manifest test to ensure the `source` entry stays in place for the demo workflow.
- Restructure the mobile touch partial into edge-aligned buttons using CSS grid around each demo grid (below `xl`). Left/right buttons span the grid height; up/down span the grid width. Mobile grid max-width is reduced slightly to make room for the control gutters.

## Verification

- `rm -rf dist && npm --prefix demo run build` succeeds
- `npm run test` (146 tests) and `npm run check` pass
- Mobile layout verified: arrow buttons sit outside the grid edges and taps trigger movement
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-364c7fa4-a414-4024-8106-43c05c5f5f18"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-364c7fa4-a414-4024-8106-43c05c5f5f18"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

