### PR TITLE
docs: polish GitHub Pages site and mobile demo layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 <small>or other things that could use a 2D matrix</small>
 
+**Docs & demo (GitHub Pages):** [site home](https://tamb.github.io/game-grid/) · [API reference](https://tamb.github.io/game-grid/docs/) · [interactive demo](https://tamb.github.io/game-grid/demo/output.html)
+
 ## Goals
 
 - 2D grid in memory with coordinates and movement rules
@@ -12,6 +14,8 @@
 - Have fun with it
 
 ## Demo (Parcel app)
+
+Try the [published demo](https://tamb.github.io/game-grid/demo/output.html) on GitHub Pages, or run it locally (below).
 
 The **`demo/`** package depends on this library via **`"@tamb/gamegrid": "file:.."`** so `npm install` inside **`demo/`** always picks up the built **`dist/`** next to it (no **`npm pack`** tarball).
 
@@ -51,7 +55,7 @@ After a change to the library, run **`npm run build`** again so **`dist/`** upda
 
 ## API documentation (TypeDoc)
 
-Generate TypeDoc-only:
+Browse the [published API reference](https://tamb.github.io/game-grid/docs/) on GitHub Pages, or generate HTML locally:
 
 ```bash
 npm run docs
@@ -68,6 +72,8 @@ npm run gh-pages
 That clears **`gh-pages/docs`** and **`gh-pages/demo`**, **`npm run build`**, reinstalls **`demo/`** deps, runs TypeDoc to **`gh-pages/docs`**, and **`parcel build`** to **`gh-pages/demo/`**. The checked-in **`gh-pages/index.html`** links to **`demo/output.html`** and **`docs/`**.
 
 ## GitHub Pages
+
+Live site: **https://tamb.github.io/game-grid/** (API docs at **`/docs/`**, demo at **`/demo/output.html`**).
 
 Use **`gh-pages/`** as the site root **`/`**: keep **`index.html`** and **`.nojekyll`** tracked. Generated **`gh-pages/docs/`** and **`gh-pages/demo/`** are **gitignored** (so they won't show up in `git status`) — editors may hide gitignored folders; this repo sets **`explorer.excludeGitIgnore`** to **`false`** in **`.vscode/settings.json`** so `gh-pages/demo` stays visible locally. Confirm with **`ls gh-pages/demo`** after **`npm run gh-pages`**.
 
@@ -376,7 +382,7 @@ export const gridEventsEnum = {
 };
 ```
 
-This mirrors **`src/enums.ts`** (same keys and string literals). Import **`gridEventsEnum`** or **`gameGridEventsEnum`** from **`@tamb/gamegrid`** rather than duplicating. **`npm run docs`** expands the same members with full cross-links.
+This mirrors **`src/enums.ts`** (same keys and string literals). Import **`gridEventsEnum`** or **`gameGridEventsEnum`** from **`@tamb/gamegrid`** rather than duplicating. The [published TypeDoc site](https://tamb.github.io/game-grid/docs/) (or **`npm run docs`** locally) expands the same members with full cross-links.
 
 ## Instantiation quick start
 

--- a/demo/src/index.html
+++ b/demo/src/index.html
@@ -11,25 +11,31 @@
       defer
       src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"
     ></script>
-    <title>GameGrid Demos</title>
+    <title>GameGrid Demos · @tamb/gamegrid</title>
   </head>
-  <body>
+  <body class="site-body site-body--demo">
+    {{> site-header}}
     {{> offcanvas-demolist}}
-    <div class="container-fluid px-3 px-md-4 py-3">
+    <div class="container-fluid site-demo px-3 px-md-4 py-3">
       <div class="row">
         <div class="col-12">
           <div
-            class="d-flex flex-wrap align-items-center justify-content-between gap-2 mb-3"
+            class="site-demo__toolbar d-flex flex-wrap align-items-center justify-content-between gap-2 mb-3"
           >
-            <h1 class="mb-0 h5">GameGrid Demos</h1>
+            <div>
+              <h1 class="site-demo__title mb-0">Interactive demos</h1>
+              <p class="site-demo__subtitle text-muted small mb-0">
+                WASD, arrow keys, or on-screen controls on smaller screens.
+              </p>
+            </div>
             <button
               type="button"
-              class="btn btn-outline-primary"
+              class="btn btn-outline-primary site-demo__menu-btn"
               data-bs-toggle="offcanvas"
               data-bs-target="#demoMenu"
               aria-controls="demoMenu"
             >
-              Demos
+              Demo gallery
             </button>
           </div>
         </div>
@@ -38,15 +44,18 @@
           {{> zoommaze}} {{> mobilecomponent}}
         </div>
       </div>
-      <div class="row">
-        <div class="col-12">
-          <div class="small p-3 word-break">
-            <p><a href="https://opengameart.org/content/animated-pirate-captain">pirate art</a></p>
-            <p><a href="https://opengameart.org/content/grass-tiles-0">grass art</a></p>
-            <p><a href="https://opengameart.org/content/wooden-box-pixel-art-32x32">box art</a></p>
-          </div>
-        </div>
-      </div>
+      <footer class="site-demo__footer">
+        <p class="small text-muted mb-2">
+          Art credits:
+          <a href="https://opengameart.org/content/animated-pirate-captain">pirate</a>,
+          <a href="https://opengameart.org/content/grass-tiles-0">grass</a>,
+          <a href="https://opengameart.org/content/wooden-box-pixel-art-32x32">box</a>
+          ·
+          <a href="https://tamb.github.io/game-grid/docs/">API docs</a>
+          ·
+          <a href="https://github.com/tamb/game-grid">GitHub</a>
+        </p>
+      </footer>
     </div>
     <script type="module" src="js/main.ts"></script>
   </body>

--- a/demo/src/output.html
+++ b/demo/src/output.html
@@ -11,9 +11,31 @@
       defer
       src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"
     ></script>
-    <title>GameGrid Demos</title>
+    <title>GameGrid Demos · @tamb/gamegrid</title>
   </head>
-  <body>
+  <body class="site-body site-body--demo">
+    <header class="site-header">
+      <div class="container-fluid site-header__inner px-3 px-md-4">
+        <a class="site-brand" href="https://tamb.github.io/game-grid/">
+          <span class="site-brand__mark" aria-hidden="true">▦</span>
+          <span class="site-brand__text">GameGrid</span>
+          <span class="site-brand__pkg">@tamb/gamegrid</span>
+        </a>
+        <nav class="site-nav" aria-label="Site">
+          <a class="site-nav__link" href="https://tamb.github.io/game-grid/">Home</a>
+          <a
+            class="site-nav__link site-nav__link--active"
+            href="https://tamb.github.io/game-grid/demo/output.html"
+            >Demos</a>
+          <a class="site-nav__link" href="https://tamb.github.io/game-grid/docs/">API docs</a>
+          <a
+            class="site-nav__link"
+            href="https://github.com/tamb/game-grid"
+            rel="noopener noreferrer"
+            >GitHub</a>
+        </nav>
+      </div>
+    </header>
     <div
       class='offcanvas offcanvas-start'
       tabindex='-1'
@@ -88,21 +110,26 @@
         </nav>
       </div>
     </div>
-    <div class="container-fluid px-3 px-md-4 py-3">
+    <div class="container-fluid site-demo px-3 px-md-4 py-3">
       <div class="row">
         <div class="col-12">
           <div
-            class="d-flex flex-wrap align-items-center justify-content-between gap-2 mb-3"
+            class="site-demo__toolbar d-flex flex-wrap align-items-center justify-content-between gap-2 mb-3"
           >
-            <h1 class="mb-0 h5">GameGrid Demos</h1>
+            <div>
+              <h1 class="site-demo__title mb-0">Interactive demos</h1>
+              <p class="site-demo__subtitle text-muted small mb-0">
+                WASD, arrow keys, or on-screen controls on smaller screens.
+              </p>
+            </div>
             <button
               type="button"
-              class="btn btn-outline-primary"
+              class="btn btn-outline-primary site-demo__menu-btn"
               data-bs-toggle="offcanvas"
               data-bs-target="#demoMenu"
               aria-controls="demoMenu"
             >
-              Demos
+              Demo gallery
             </button>
           </div>
         </div>
@@ -134,44 +161,36 @@
     </div>
     <div class='col-12 col-xl-4 order-1 order-xl-2'>
       <div class='demo-grid-wrap mx-auto'>
-        <div id='maze3'></div>
+        <div class='demo-grid-mount' id='maze3'></div>
         <div
           id='coin-demo-dpad'
-          class='gamegrid-touch-controls d-xl-none mt-3'
+          class='gamegrid-touch-controls d-xl-none'
           aria-label='On-screen movement controls'
         >
-          <div class='gamegrid-dpad' role='group' aria-label='Move in the grid'>
-            <div class='gamegrid-dpad-row gamegrid-dpad-row--up'>
-              <button
-                type='button'
-                class='btn btn-outline-primary gamegrid-dpad-btn'
-                data-gamegrid-move='up'
-                aria-label='Move up'
-              >↑</button>
-            </div>
-            <div class='gamegrid-dpad-row gamegrid-dpad-row--mid'>
-              <button
-                type='button'
-                class='btn btn-outline-primary gamegrid-dpad-btn'
-                data-gamegrid-move='left'
-                aria-label='Move left'
-              >←</button>
-              <button
-                type='button'
-                class='btn btn-outline-primary gamegrid-dpad-btn'
-                data-gamegrid-move='right'
-                aria-label='Move right'
-              >→</button>
-            </div>
-            <div class='gamegrid-dpad-row gamegrid-dpad-row--down'>
-              <button
-                type='button'
-                class='btn btn-outline-primary gamegrid-dpad-btn'
-                data-gamegrid-move='down'
-                aria-label='Move down'
-              >↓</button>
-            </div>
-          </div>
+          <button
+            type='button'
+            class='btn btn-outline-primary gamegrid-dpad-btn gamegrid-dpad-btn--up'
+            data-gamegrid-move='up'
+            aria-label='Move up'
+          >↑</button>
+          <button
+            type='button'
+            class='btn btn-outline-primary gamegrid-dpad-btn gamegrid-dpad-btn--left'
+            data-gamegrid-move='left'
+            aria-label='Move left'
+          >←</button>
+          <button
+            type='button'
+            class='btn btn-outline-primary gamegrid-dpad-btn gamegrid-dpad-btn--right'
+            data-gamegrid-move='right'
+            aria-label='Move right'
+          >→</button>
+          <button
+            type='button'
+            class='btn btn-outline-primary gamegrid-dpad-btn gamegrid-dpad-btn--down'
+            data-gamegrid-move='down'
+            aria-label='Move down'
+          >↓</button>
         </div>
       </div>
     </div>
@@ -181,44 +200,36 @@
   <div class='row g-3'>
     <div class='col-12 col-lg-5 col-xl-4'>
       <div class='demo-grid-wrap mx-auto'>
-        <div id='grid1'></div>
+        <div class='demo-grid-mount' id='grid1'></div>
         <div
           id='events-demo-dpad'
-          class='gamegrid-touch-controls d-xl-none mt-3'
+          class='gamegrid-touch-controls d-xl-none'
           aria-label='On-screen movement controls'
         >
-          <div class='gamegrid-dpad' role='group' aria-label='Move in the grid'>
-            <div class='gamegrid-dpad-row gamegrid-dpad-row--up'>
-              <button
-                type='button'
-                class='btn btn-outline-primary gamegrid-dpad-btn'
-                data-gamegrid-move='up'
-                aria-label='Move up'
-              >↑</button>
-            </div>
-            <div class='gamegrid-dpad-row gamegrid-dpad-row--mid'>
-              <button
-                type='button'
-                class='btn btn-outline-primary gamegrid-dpad-btn'
-                data-gamegrid-move='left'
-                aria-label='Move left'
-              >←</button>
-              <button
-                type='button'
-                class='btn btn-outline-primary gamegrid-dpad-btn'
-                data-gamegrid-move='right'
-                aria-label='Move right'
-              >→</button>
-            </div>
-            <div class='gamegrid-dpad-row gamegrid-dpad-row--down'>
-              <button
-                type='button'
-                class='btn btn-outline-primary gamegrid-dpad-btn'
-                data-gamegrid-move='down'
-                aria-label='Move down'
-              >↓</button>
-            </div>
-          </div>
+          <button
+            type='button'
+            class='btn btn-outline-primary gamegrid-dpad-btn gamegrid-dpad-btn--up'
+            data-gamegrid-move='up'
+            aria-label='Move up'
+          >↑</button>
+          <button
+            type='button'
+            class='btn btn-outline-primary gamegrid-dpad-btn gamegrid-dpad-btn--left'
+            data-gamegrid-move='left'
+            aria-label='Move left'
+          >←</button>
+          <button
+            type='button'
+            class='btn btn-outline-primary gamegrid-dpad-btn gamegrid-dpad-btn--right'
+            data-gamegrid-move='right'
+            aria-label='Move right'
+          >→</button>
+          <button
+            type='button'
+            class='btn btn-outline-primary gamegrid-dpad-btn gamegrid-dpad-btn--down'
+            data-gamegrid-move='down'
+            aria-label='Move down'
+          >↓</button>
         </div>
       </div>
     </div>
@@ -226,7 +237,7 @@
       <div>
         <h2>Events</h2>
         <p class='text-muted small mb-2 d-xl-none'>
-          Use the directional pad below the grid to move on touch devices.
+          Use the directional pads beside the grid to move on touch devices.
         </p>
         <div id='move-events'>
           <ul></ul>
@@ -250,44 +261,36 @@
     </div>
     <div class='col-12 col-xl-5 order-1 order-xl-2'>
       <div class='demo-grid-wrap demo-grid-wrap--tall mx-auto'>
-        <div id='maze'></div>
+        <div class='demo-grid-mount' id='maze'></div>
         <div
           id='bigmaze-demo-dpad'
-          class='gamegrid-touch-controls d-xl-none mt-3'
+          class='gamegrid-touch-controls d-xl-none'
           aria-label='On-screen movement controls'
         >
-          <div class='gamegrid-dpad' role='group' aria-label='Move in the grid'>
-            <div class='gamegrid-dpad-row gamegrid-dpad-row--up'>
-              <button
-                type='button'
-                class='btn btn-outline-primary gamegrid-dpad-btn'
-                data-gamegrid-move='up'
-                aria-label='Move up'
-              >↑</button>
-            </div>
-            <div class='gamegrid-dpad-row gamegrid-dpad-row--mid'>
-              <button
-                type='button'
-                class='btn btn-outline-primary gamegrid-dpad-btn'
-                data-gamegrid-move='left'
-                aria-label='Move left'
-              >←</button>
-              <button
-                type='button'
-                class='btn btn-outline-primary gamegrid-dpad-btn'
-                data-gamegrid-move='right'
-                aria-label='Move right'
-              >→</button>
-            </div>
-            <div class='gamegrid-dpad-row gamegrid-dpad-row--down'>
-              <button
-                type='button'
-                class='btn btn-outline-primary gamegrid-dpad-btn'
-                data-gamegrid-move='down'
-                aria-label='Move down'
-              >↓</button>
-            </div>
-          </div>
+          <button
+            type='button'
+            class='btn btn-outline-primary gamegrid-dpad-btn gamegrid-dpad-btn--up'
+            data-gamegrid-move='up'
+            aria-label='Move up'
+          >↑</button>
+          <button
+            type='button'
+            class='btn btn-outline-primary gamegrid-dpad-btn gamegrid-dpad-btn--left'
+            data-gamegrid-move='left'
+            aria-label='Move left'
+          >←</button>
+          <button
+            type='button'
+            class='btn btn-outline-primary gamegrid-dpad-btn gamegrid-dpad-btn--right'
+            data-gamegrid-move='right'
+            aria-label='Move right'
+          >→</button>
+          <button
+            type='button'
+            class='btn btn-outline-primary gamegrid-dpad-btn gamegrid-dpad-btn--down'
+            data-gamegrid-move='down'
+            aria-label='Move down'
+          >↓</button>
         </div>
       </div>
     </div>
@@ -314,44 +317,36 @@
     </div>
     <div class='col-12 col-xl-5 order-1 order-xl-2'>
       <div class='demo-grid-wrap mx-auto'>
-        <div id='maze2'></div>
+        <div class='demo-grid-mount' id='maze2'></div>
         <div
           id='minimaze-demo-dpad'
-          class='gamegrid-touch-controls d-xl-none mt-3'
+          class='gamegrid-touch-controls d-xl-none'
           aria-label='On-screen movement controls'
         >
-          <div class='gamegrid-dpad' role='group' aria-label='Move in the grid'>
-            <div class='gamegrid-dpad-row gamegrid-dpad-row--up'>
-              <button
-                type='button'
-                class='btn btn-outline-primary gamegrid-dpad-btn'
-                data-gamegrid-move='up'
-                aria-label='Move up'
-              >↑</button>
-            </div>
-            <div class='gamegrid-dpad-row gamegrid-dpad-row--mid'>
-              <button
-                type='button'
-                class='btn btn-outline-primary gamegrid-dpad-btn'
-                data-gamegrid-move='left'
-                aria-label='Move left'
-              >←</button>
-              <button
-                type='button'
-                class='btn btn-outline-primary gamegrid-dpad-btn'
-                data-gamegrid-move='right'
-                aria-label='Move right'
-              >→</button>
-            </div>
-            <div class='gamegrid-dpad-row gamegrid-dpad-row--down'>
-              <button
-                type='button'
-                class='btn btn-outline-primary gamegrid-dpad-btn'
-                data-gamegrid-move='down'
-                aria-label='Move down'
-              >↓</button>
-            </div>
-          </div>
+          <button
+            type='button'
+            class='btn btn-outline-primary gamegrid-dpad-btn gamegrid-dpad-btn--up'
+            data-gamegrid-move='up'
+            aria-label='Move up'
+          >↑</button>
+          <button
+            type='button'
+            class='btn btn-outline-primary gamegrid-dpad-btn gamegrid-dpad-btn--left'
+            data-gamegrid-move='left'
+            aria-label='Move left'
+          >←</button>
+          <button
+            type='button'
+            class='btn btn-outline-primary gamegrid-dpad-btn gamegrid-dpad-btn--right'
+            data-gamegrid-move='right'
+            aria-label='Move right'
+          >→</button>
+          <button
+            type='button'
+            class='btn btn-outline-primary gamegrid-dpad-btn gamegrid-dpad-btn--down'
+            data-gamegrid-move='down'
+            aria-label='Move down'
+          >↓</button>
         </div>
       </div>
     </div>
@@ -390,44 +385,36 @@
     </div>
     <div class='col-12 col-xl-5 order-1 order-xl-2'>
       <div class='demo-grid-wrap demo-grid-wrap--zoom mx-auto'>
-        <div id='zoom-maze'></div>
+        <div class='demo-grid-mount' id='zoom-maze'></div>
         <div
           id='zoommaze-demo-dpad'
-          class='gamegrid-touch-controls d-xl-none mt-3'
+          class='gamegrid-touch-controls d-xl-none'
           aria-label='On-screen movement controls'
         >
-          <div class='gamegrid-dpad' role='group' aria-label='Move in the grid'>
-            <div class='gamegrid-dpad-row gamegrid-dpad-row--up'>
-              <button
-                type='button'
-                class='btn btn-outline-primary gamegrid-dpad-btn'
-                data-gamegrid-move='up'
-                aria-label='Move up'
-              >↑</button>
-            </div>
-            <div class='gamegrid-dpad-row gamegrid-dpad-row--mid'>
-              <button
-                type='button'
-                class='btn btn-outline-primary gamegrid-dpad-btn'
-                data-gamegrid-move='left'
-                aria-label='Move left'
-              >←</button>
-              <button
-                type='button'
-                class='btn btn-outline-primary gamegrid-dpad-btn'
-                data-gamegrid-move='right'
-                aria-label='Move right'
-              >→</button>
-            </div>
-            <div class='gamegrid-dpad-row gamegrid-dpad-row--down'>
-              <button
-                type='button'
-                class='btn btn-outline-primary gamegrid-dpad-btn'
-                data-gamegrid-move='down'
-                aria-label='Move down'
-              >↓</button>
-            </div>
-          </div>
+          <button
+            type='button'
+            class='btn btn-outline-primary gamegrid-dpad-btn gamegrid-dpad-btn--up'
+            data-gamegrid-move='up'
+            aria-label='Move up'
+          >↑</button>
+          <button
+            type='button'
+            class='btn btn-outline-primary gamegrid-dpad-btn gamegrid-dpad-btn--left'
+            data-gamegrid-move='left'
+            aria-label='Move left'
+          >←</button>
+          <button
+            type='button'
+            class='btn btn-outline-primary gamegrid-dpad-btn gamegrid-dpad-btn--right'
+            data-gamegrid-move='right'
+            aria-label='Move right'
+          >→</button>
+          <button
+            type='button'
+            class='btn btn-outline-primary gamegrid-dpad-btn gamegrid-dpad-btn--down'
+            data-gamegrid-move='down'
+            aria-label='Move down'
+          >↓</button>
         </div>
       </div>
     </div>
@@ -438,8 +425,8 @@
     <div class='col-12 col-xl-7 order-2 order-xl-1'>
       <h2>Mobile Component</h2>
       <p>
-        Move around the grid with WASD / arrow keys, or use the directional pad
-        below the grid on touch-sized viewports.
+        Move around the grid with WASD / arrow keys, or use the directional pads
+        beside the grid on touch-sized viewports.
       </p>
       <p>
         The grid logs move details to the browser console when you land on a
@@ -448,44 +435,36 @@
     </div>
     <div class='col-12 col-xl-5 order-1 order-xl-2'>
       <div class='demo-grid-wrap mx-auto'>
-        <div id='mobile-component-grid'></div>
+        <div class='demo-grid-mount' id='mobile-component-grid'></div>
         <div
           id='mobile-demo-dpad'
-          class='gamegrid-touch-controls d-xl-none mt-3'
+          class='gamegrid-touch-controls d-xl-none'
           aria-label='On-screen movement controls'
         >
-          <div class='gamegrid-dpad' role='group' aria-label='Move in the grid'>
-            <div class='gamegrid-dpad-row gamegrid-dpad-row--up'>
-              <button
-                type='button'
-                class='btn btn-outline-primary gamegrid-dpad-btn'
-                data-gamegrid-move='up'
-                aria-label='Move up'
-              >↑</button>
-            </div>
-            <div class='gamegrid-dpad-row gamegrid-dpad-row--mid'>
-              <button
-                type='button'
-                class='btn btn-outline-primary gamegrid-dpad-btn'
-                data-gamegrid-move='left'
-                aria-label='Move left'
-              >←</button>
-              <button
-                type='button'
-                class='btn btn-outline-primary gamegrid-dpad-btn'
-                data-gamegrid-move='right'
-                aria-label='Move right'
-              >→</button>
-            </div>
-            <div class='gamegrid-dpad-row gamegrid-dpad-row--down'>
-              <button
-                type='button'
-                class='btn btn-outline-primary gamegrid-dpad-btn'
-                data-gamegrid-move='down'
-                aria-label='Move down'
-              >↓</button>
-            </div>
-          </div>
+          <button
+            type='button'
+            class='btn btn-outline-primary gamegrid-dpad-btn gamegrid-dpad-btn--up'
+            data-gamegrid-move='up'
+            aria-label='Move up'
+          >↑</button>
+          <button
+            type='button'
+            class='btn btn-outline-primary gamegrid-dpad-btn gamegrid-dpad-btn--left'
+            data-gamegrid-move='left'
+            aria-label='Move left'
+          >←</button>
+          <button
+            type='button'
+            class='btn btn-outline-primary gamegrid-dpad-btn gamegrid-dpad-btn--right'
+            data-gamegrid-move='right'
+            aria-label='Move right'
+          >→</button>
+          <button
+            type='button'
+            class='btn btn-outline-primary gamegrid-dpad-btn gamegrid-dpad-btn--down'
+            data-gamegrid-move='down'
+            aria-label='Move down'
+          >↓</button>
         </div>
       </div>
     </div>
@@ -493,15 +472,18 @@
 </div>
         </div>
       </div>
-      <div class="row">
-        <div class="col-12">
-          <div class="small p-3 word-break">
-            <p><a href="https://opengameart.org/content/animated-pirate-captain">pirate art</a></p>
-            <p><a href="https://opengameart.org/content/grass-tiles-0">grass art</a></p>
-            <p><a href="https://opengameart.org/content/wooden-box-pixel-art-32x32">box art</a></p>
-          </div>
-        </div>
-      </div>
+      <footer class="site-demo__footer">
+        <p class="small text-muted mb-2">
+          Art credits:
+          <a href="https://opengameart.org/content/animated-pirate-captain">pirate</a>,
+          <a href="https://opengameart.org/content/grass-tiles-0">grass</a>,
+          <a href="https://opengameart.org/content/wooden-box-pixel-art-32x32">box</a>
+          ·
+          <a href="https://tamb.github.io/game-grid/docs/">API docs</a>
+          ·
+          <a href="https://github.com/tamb/game-grid">GitHub</a>
+        </p>
+      </footer>
     </div>
     <script type="module" src="js/main.ts"></script>
   </body>

--- a/demo/src/partials/site-header.hbs
+++ b/demo/src/partials/site-header.hbs
@@ -1,0 +1,22 @@
+<header class="site-header">
+  <div class="container-fluid site-header__inner px-3 px-md-4">
+    <a class="site-brand" href="https://tamb.github.io/game-grid/">
+      <span class="site-brand__mark" aria-hidden="true">▦</span>
+      <span class="site-brand__text">GameGrid</span>
+      <span class="site-brand__pkg">@tamb/gamegrid</span>
+    </a>
+    <nav class="site-nav" aria-label="Site">
+      <a class="site-nav__link" href="https://tamb.github.io/game-grid/">Home</a>
+      <a
+        class="site-nav__link site-nav__link--active"
+        href="https://tamb.github.io/game-grid/demo/output.html"
+        >Demos</a>
+      <a class="site-nav__link" href="https://tamb.github.io/game-grid/docs/">API docs</a>
+      <a
+        class="site-nav__link"
+        href="https://github.com/tamb/game-grid"
+        rel="noopener noreferrer"
+        >GitHub</a>
+    </nav>
+  </div>
+</header>

--- a/demo/src/styles/styles.scss
+++ b/demo/src/styles/styles.scss
@@ -1,3 +1,200 @@
+/* Site chrome (GitHub Pages landing + demo bundle) */
+
+:root {
+  --gg-bg: #0c1017;
+  --gg-bg-elevated: #141b26;
+  --gg-surface: #1a2332;
+  --gg-surface-hover: #222d3f;
+  --gg-border: #2d3a4f;
+  --gg-text: #e8edf4;
+  --gg-text-muted: #94a3b8;
+  --gg-accent: #38bdf8;
+  --gg-accent-strong: #0ea5e9;
+}
+
+.site-body--demo {
+  background:
+    radial-gradient(ellipse 70% 40% at 50% -10%, rgba(56, 189, 248, 0.12), transparent),
+    linear-gradient(180deg, #0f1623 0%, var(--gg-bg) 38%);
+  background-color: var(--gg-bg);
+  color: var(--gg-text);
+  min-height: 100vh;
+}
+
+.site-header {
+  position: sticky;
+  top: 0;
+  z-index: 1040;
+  border-bottom: 1px solid var(--gg-border);
+  background: rgba(12, 16, 23, 0.9);
+  backdrop-filter: blur(10px);
+}
+
+.site-header__inner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  max-width: 72rem;
+  margin: 0 auto;
+  padding: 0.85rem 0;
+}
+
+.site-brand {
+  display: flex;
+  align-items: center;
+  gap: 0.55rem;
+  color: var(--gg-text);
+  font-weight: 650;
+  letter-spacing: -0.02em;
+  text-decoration: none;
+}
+
+.site-brand:hover {
+  color: var(--gg-text);
+}
+
+.site-brand__mark {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 8px;
+  background: linear-gradient(145deg, var(--gg-accent-strong), #6366f1);
+  font-size: 0.95rem;
+  line-height: 1;
+  box-shadow: 0 4px 14px rgba(14, 165, 233, 0.35);
+}
+
+.site-brand__text {
+  font-size: 1.1rem;
+}
+
+.site-brand__pkg {
+  font-family: ui-monospace, monospace;
+  font-size: 0.72rem;
+  font-weight: 500;
+  color: var(--gg-text-muted);
+  padding: 0.15rem 0.45rem;
+  border: 1px solid var(--gg-border);
+  border-radius: 999px;
+  background: var(--gg-bg-elevated);
+}
+
+.site-nav {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  flex-wrap: wrap;
+}
+
+.site-nav__link {
+  display: inline-block;
+  padding: 0.4rem 0.75rem;
+  border-radius: 999px;
+  color: var(--gg-text-muted);
+  font-size: 0.9rem;
+  font-weight: 500;
+  text-decoration: none;
+  transition:
+    color 0.15s ease,
+    background 0.15s ease;
+}
+
+.site-nav__link:hover {
+  color: var(--gg-text);
+  background: var(--gg-surface);
+}
+
+.site-nav__link--active {
+  color: var(--gg-text);
+  background: var(--gg-surface);
+  border: 1px solid var(--gg-border);
+}
+
+.site-demo {
+  max-width: 72rem;
+  margin: 0 auto;
+}
+
+.site-demo__title {
+  font-size: 1.35rem;
+  font-weight: 650;
+  letter-spacing: -0.02em;
+  color: var(--gg-text);
+}
+
+.site-demo__subtitle {
+  color: var(--gg-text-muted) !important;
+}
+
+.site-demo__menu-btn {
+  border-color: var(--gg-border);
+  color: var(--gg-accent);
+}
+
+.site-demo__menu-btn:hover {
+  background: var(--gg-surface);
+  border-color: rgba(56, 189, 248, 0.45);
+  color: var(--gg-accent);
+}
+
+.site-demo__footer {
+  margin-top: 2rem;
+  padding-top: 1rem;
+  border-top: 1px solid var(--gg-border);
+}
+
+.site-demo__footer a {
+  color: var(--gg-accent);
+}
+
+.site-body--demo .offcanvas {
+  background: var(--gg-bg-elevated);
+  color: var(--gg-text);
+  border-right: 1px solid var(--gg-border);
+}
+
+.site-body--demo .offcanvas-header {
+  border-bottom-color: var(--gg-border) !important;
+}
+
+.site-body--demo .text-muted {
+  color: var(--gg-text-muted) !important;
+}
+
+.site-body--demo h2 {
+  color: var(--gg-text);
+}
+
+.site-body--demo .demo-pane p {
+  color: var(--gg-text-muted);
+}
+
+.site-body--demo .btn-outline-secondary {
+  border-color: var(--gg-border);
+  color: var(--gg-text-muted);
+}
+
+.site-body--demo .btn-outline-secondary:hover {
+  background: var(--gg-surface);
+  border-color: var(--gg-border);
+  color: var(--gg-text);
+}
+
+.site-body--demo .btn-primary {
+  background: linear-gradient(135deg, #38bdf8, #0ea5e9);
+  border-color: transparent;
+  color: #041018;
+}
+
+@media (max-width: 640px) {
+  .site-brand__pkg {
+    display: none;
+  }
+}
+
 /* Coin Collector (`#maze3`): tiles + pirate avatar only apply here */
 
 #maze3 {
@@ -120,38 +317,44 @@
   overflow: auto;
 }
 
-/* Mobile: anchor d-pad arrows to the outer edges of the grid */
+/* Mobile: grid 85vw with 7vw side controls (99vw total) */
 @media (max-width: 1199.98px) {
   .demo-grid-wrap {
     display: grid;
-    grid-template-columns: auto minmax(0, 1fr) auto;
+    grid-template-columns: 7vw 85vw 7vw;
     grid-template-rows: auto minmax(0, 1fr) auto;
     grid-template-areas:
       '. up .'
       'left grid right'
       '. down .';
-    gap: 0.25rem;
+    gap: 0;
     align-items: stretch;
     justify-items: stretch;
-    max-width: min(calc(100% - 0.5rem), 460px);
+    width: 99vw;
+    max-width: 99vw;
+    margin-left: auto;
+    margin-right: auto;
     overflow: visible;
   }
 
   .demo-grid-wrap--tall {
-    max-width: min(calc(100% - 0.5rem), 480px);
-    max-height: min(62vh, 580px);
+    width: 99vw;
+    max-width: 99vw;
+    max-height: none;
     overflow: visible;
   }
 
   .demo-grid-wrap--zoom {
-    max-width: min(calc(100% - 0.5rem), 260px);
-    max-height: min(40vh, 260px);
+    width: 99vw;
+    max-width: 99vw;
+    max-height: none;
     overflow: visible;
   }
 
   .demo-grid-wrap > .demo-grid-mount {
     grid-area: grid;
-    width: 100%;
+    width: 85vw;
+    max-width: 85vw;
     min-width: 0;
     min-height: 0;
     overflow: auto;
@@ -159,11 +362,11 @@
   }
 
   .demo-grid-wrap--tall > .demo-grid-mount {
-    max-height: min(62vh, 580px);
+    max-height: min(70vh, 85vw);
   }
 
   .demo-grid-wrap--zoom > .demo-grid-mount {
-    max-height: min(40vh, 260px);
+    max-height: min(55vh, 85vw);
   }
 
   .demo-grid-wrap .gamegrid-touch-controls {
@@ -242,31 +445,40 @@ $zoom-quadrant-se: #f9a8d4;
 }
 
 @media (max-width: 1199.98px) {
+  .gamegrid-dpad-btn {
+    min-width: 0;
+    min-height: 2.75rem;
+    padding: 0.25rem;
+    font-size: 1.15rem;
+  }
+
   .gamegrid-dpad-btn--up {
     grid-area: up;
     justify-self: stretch;
-    width: 100%;
-    min-height: 2.75rem;
+    width: 85vw;
+    max-width: 85vw;
   }
 
   .gamegrid-dpad-btn--left {
     grid-area: left;
     align-self: stretch;
+    width: 7vw;
+    max-width: 7vw;
     height: 100%;
-    min-width: 2.75rem;
   }
 
   .gamegrid-dpad-btn--right {
     grid-area: right;
     align-self: stretch;
+    width: 7vw;
+    max-width: 7vw;
     height: 100%;
-    min-width: 2.75rem;
   }
 
   .gamegrid-dpad-btn--down {
     grid-area: down;
     justify-self: stretch;
-    width: 100%;
-    min-height: 2.75rem;
+    width: 85vw;
+    max-width: 85vw;
   }
 }

--- a/gh-pages/index.html
+++ b/gh-pages/index.html
@@ -3,23 +3,91 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>@tamb/gamegrid</title>
-    <style>
-      body {
-        font-family: system-ui, sans-serif;
-        max-width: 36rem;
-        margin: 2rem auto;
-        padding: 0 1rem;
-        line-height: 1.5;
-      }
-    </style>
+    <meta
+      name="description"
+      content="GameGrid — a TypeScript library for 2D grid-based web games and interactive matrices."
+    />
+    <title>GameGrid · @tamb/gamegrid</title>
+    <link rel="stylesheet" href="site.css" />
   </head>
   <body>
-    <h1>@tamb/gamegrid</h1>
-    <p>Static previews from the repository build.</p>
-    <ul>
-      <li><a href="demo/output.html">Demo (Parcel bundle)</a></li>
-      <li><a href="docs/index.html">TypeDoc API reference</a></li>
-    </ul>
+    <header class="site-header">
+      <div class="site-header__inner">
+        <a class="site-brand" href="./">
+          <span class="site-brand__mark" aria-hidden="true">▦</span>
+          <span class="site-brand__text">GameGrid</span>
+          <span class="site-brand__pkg">@tamb/gamegrid</span>
+        </a>
+        <nav class="site-nav" aria-label="Site">
+          <a class="site-nav__link site-nav__link--active" href="./">Home</a>
+          <a class="site-nav__link" href="demo/output.html">Demos</a>
+          <a class="site-nav__link" href="docs/">API docs</a>
+          <a
+            class="site-nav__link"
+            href="https://github.com/tamb/game-grid"
+            rel="noopener noreferrer"
+            >GitHub</a
+          >
+        </nav>
+      </div>
+    </header>
+
+    <main class="site-main">
+      <section class="hero">
+        <p class="hero__badge">TypeScript · DOM-optional · MIT</p>
+        <h1>A 2D grid for web games</h1>
+        <p class="hero__lead">
+          Stateful coordinates, movement rules, events, zoom regions, and optional
+          rendering — or use it headless as a pure matrix API.
+        </p>
+        <div class="hero__actions">
+          <a class="btn btn--primary" href="demo/output.html">Try interactive demos</a>
+          <a class="btn btn--secondary" href="docs/">Browse API reference</a>
+        </div>
+      </section>
+
+      <section class="card-grid" aria-label="Resources">
+        <a class="card" href="demo/output.html">
+          <span class="card__icon" aria-hidden="true">🎮</span>
+          <h2>Interactive demos</h2>
+          <p>
+            Coin mazes, event logging, zoom quadrants, and mobile touch controls —
+            all built with the library.
+          </p>
+          <span class="card__arrow">Open demos →</span>
+        </a>
+        <a class="card" href="docs/">
+          <span class="card__icon" aria-hidden="true">📖</span>
+          <h2>API reference</h2>
+          <p>
+            Full TypeDoc coverage for <code>GameGrid</code>, options, events, zoom
+            helpers, and exported types.
+          </p>
+          <span class="card__arrow">Read the docs →</span>
+        </a>
+        <a
+          class="card"
+          href="https://github.com/tamb/game-grid"
+          rel="noopener noreferrer"
+        >
+          <span class="card__icon" aria-hidden="true">⌥</span>
+          <h2>Source on GitHub</h2>
+          <p>
+            Issues, releases, and the full README with install instructions and
+            configuration examples.
+          </p>
+          <span class="card__arrow">View repository →</span>
+        </a>
+      </section>
+
+      <footer class="site-footer">
+        <p>
+          MIT License ·
+          <a href="https://github.com/tamb/game-grid">tamb/game-grid</a>
+          · Demo art credits on the
+          <a href="demo/output.html">demos page</a>
+        </p>
+      </footer>
+    </main>
   </body>
 </html>

--- a/gh-pages/site.css
+++ b/gh-pages/site.css
@@ -1,0 +1,326 @@
+:root {
+  color-scheme: dark;
+  --gg-bg: #0c1017;
+  --gg-bg-elevated: #141b26;
+  --gg-surface: #1a2332;
+  --gg-surface-hover: #222d3f;
+  --gg-border: #2d3a4f;
+  --gg-text: #e8edf4;
+  --gg-text-muted: #94a3b8;
+  --gg-accent: #38bdf8;
+  --gg-accent-strong: #0ea5e9;
+  --gg-accent-glow: rgba(56, 189, 248, 0.18);
+  --gg-radius: 12px;
+  --gg-radius-lg: 18px;
+  --gg-shadow: 0 18px 48px rgba(0, 0, 0, 0.35);
+  --gg-font: "Segoe UI", system-ui, -apple-system, sans-serif;
+  --gg-mono: ui-monospace, "Cascadia Code", "Source Code Pro", monospace;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: var(--gg-font);
+  font-size: 1rem;
+  line-height: 1.6;
+  color: var(--gg-text);
+  background:
+    radial-gradient(ellipse 80% 50% at 50% -20%, var(--gg-accent-glow), transparent),
+    linear-gradient(180deg, #0f1623 0%, var(--gg-bg) 42%);
+  background-color: var(--gg-bg);
+}
+
+a {
+  color: var(--gg-accent);
+  text-decoration: none;
+}
+
+a:hover {
+  color: #7dd3fc;
+}
+
+.site-header {
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  border-bottom: 1px solid var(--gg-border);
+  background: rgba(12, 16, 23, 0.88);
+  backdrop-filter: blur(10px);
+}
+
+.site-header__inner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  max-width: 72rem;
+  margin: 0 auto;
+  padding: 0.85rem 1.25rem;
+}
+
+.site-brand {
+  display: flex;
+  align-items: center;
+  gap: 0.55rem;
+  color: var(--gg-text);
+  font-weight: 650;
+  letter-spacing: -0.02em;
+}
+
+.site-brand:hover {
+  color: var(--gg-text);
+}
+
+.site-brand__mark {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 8px;
+  background: linear-gradient(145deg, var(--gg-accent-strong), #6366f1);
+  font-size: 0.95rem;
+  line-height: 1;
+  box-shadow: 0 4px 14px rgba(14, 165, 233, 0.35);
+}
+
+.site-brand__text {
+  font-size: 1.1rem;
+}
+
+.site-brand__pkg {
+  font-family: var(--gg-mono);
+  font-size: 0.72rem;
+  font-weight: 500;
+  color: var(--gg-text-muted);
+  padding: 0.15rem 0.45rem;
+  border: 1px solid var(--gg-border);
+  border-radius: 999px;
+  background: var(--gg-bg-elevated);
+}
+
+.site-nav {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  flex-wrap: wrap;
+}
+
+.site-nav__link {
+  display: inline-block;
+  padding: 0.4rem 0.75rem;
+  border-radius: 999px;
+  color: var(--gg-text-muted);
+  font-size: 0.9rem;
+  font-weight: 500;
+  transition:
+    color 0.15s ease,
+    background 0.15s ease;
+}
+
+.site-nav__link:hover {
+  color: var(--gg-text);
+  background: var(--gg-surface);
+}
+
+.site-nav__link--active {
+  color: var(--gg-text);
+  background: var(--gg-surface);
+  border: 1px solid var(--gg-border);
+}
+
+.site-main {
+  max-width: 72rem;
+  margin: 0 auto;
+  padding: 2rem 1.25rem 3rem;
+}
+
+.hero {
+  text-align: center;
+  padding: 2.5rem 0 2rem;
+}
+
+.hero__badge {
+  display: inline-block;
+  margin-bottom: 1rem;
+  padding: 0.3rem 0.75rem;
+  border-radius: 999px;
+  border: 1px solid var(--gg-border);
+  background: var(--gg-surface);
+  color: var(--gg-text-muted);
+  font-size: 0.8rem;
+  font-weight: 500;
+}
+
+.hero h1 {
+  margin: 0 0 0.75rem;
+  font-size: clamp(2rem, 5vw, 2.85rem);
+  line-height: 1.15;
+  letter-spacing: -0.03em;
+  font-weight: 700;
+}
+
+.hero__lead {
+  margin: 0 auto 1.75rem;
+  max-width: 36rem;
+  color: var(--gg-text-muted);
+  font-size: 1.05rem;
+}
+
+.hero__actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 0.65rem;
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.4rem;
+  padding: 0.65rem 1.15rem;
+  border-radius: 999px;
+  border: 1px solid transparent;
+  font-size: 0.95rem;
+  font-weight: 600;
+  line-height: 1.2;
+  transition:
+    transform 0.15s ease,
+    background 0.15s ease,
+    border-color 0.15s ease,
+    box-shadow 0.15s ease;
+}
+
+.btn:hover {
+  transform: translateY(-1px);
+}
+
+.btn--primary {
+  color: #041018;
+  background: linear-gradient(135deg, #38bdf8, #0ea5e9);
+  box-shadow: 0 8px 24px rgba(14, 165, 233, 0.35);
+}
+
+.btn--primary:hover {
+  color: #041018;
+  box-shadow: 0 10px 28px rgba(14, 165, 233, 0.45);
+}
+
+.btn--secondary {
+  color: var(--gg-text);
+  background: var(--gg-surface);
+  border-color: var(--gg-border);
+}
+
+.btn--secondary:hover {
+  color: var(--gg-text);
+  background: var(--gg-surface-hover);
+}
+
+.card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(16rem, 1fr));
+  gap: 1rem;
+  margin-top: 2.5rem;
+}
+
+.card {
+  display: block;
+  padding: 1.35rem 1.25rem;
+  border-radius: var(--gg-radius-lg);
+  border: 1px solid var(--gg-border);
+  background: var(--gg-surface);
+  box-shadow: var(--gg-shadow);
+  transition:
+    transform 0.18s ease,
+    border-color 0.18s ease,
+    background 0.18s ease;
+}
+
+.card:hover {
+  transform: translateY(-3px);
+  border-color: rgba(56, 189, 248, 0.45);
+  background: var(--gg-surface-hover);
+}
+
+.card__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.25rem;
+  height: 2.25rem;
+  margin-bottom: 0.85rem;
+  border-radius: 10px;
+  background: var(--gg-bg-elevated);
+  color: var(--gg-accent);
+  font-size: 1.1rem;
+}
+
+.card h2 {
+  margin: 0 0 0.45rem;
+  font-size: 1.1rem;
+  font-weight: 650;
+  color: var(--gg-text);
+}
+
+.card p {
+  margin: 0;
+  color: var(--gg-text-muted);
+  font-size: 0.92rem;
+}
+
+.card code {
+  font-family: var(--gg-mono);
+  font-size: 0.85em;
+  color: #bae6fd;
+}
+
+.card__arrow {
+  display: block;
+  margin-top: 0.85rem;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--gg-accent);
+}
+
+.site-footer {
+  margin-top: 3rem;
+  padding-top: 1.5rem;
+  border-top: 1px solid var(--gg-border);
+  text-align: center;
+  color: var(--gg-text-muted);
+  font-size: 0.85rem;
+}
+
+.site-footer a {
+  font-weight: 500;
+}
+
+@media (max-width: 640px) {
+  .site-brand__pkg {
+    display: none;
+  }
+
+  .site-header__inner {
+    padding: 0.75rem 1rem;
+  }
+
+  .site-main {
+    padding: 1.5rem 1rem 2.5rem;
+  }
+
+  .hero {
+    padding: 1.5rem 0 1.25rem;
+  }
+}

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "@tamb/gamegrid",
   "version": "1.0.0-rc.0",
   "description": "",
+  "homepage": "https://tamb.github.io/game-grid/docs/",
   "main": "dist/main.js",
   "source": "src/index.ts",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Improves the published GitHub Pages experience with a polished landing page, consistent site chrome on demos, and wider mobile grid layout.

## Changes

### Landing page (`gh-pages/`)
- New dark-themed design with sticky nav, hero, resource cards, and footer
- Links to demos, TypeDoc API reference, and GitHub
- Shared `site.css` for layout and typography

### Demo bundle (`demo/`)
- Site header with Home / Demos / API docs / GitHub links
- Footer with art credits and doc/repo links
- Mobile grid layout: **85vw** play area with **7vw** side d-pad buttons (**99vw** total)

### Docs (`README.md`, `package.json`)
- README links to live GitHub Pages URLs
- `homepage` field points to published TypeDoc

## Live URLs

- Site: https://tamb.github.io/game-grid/
- API docs: https://tamb.github.io/game-grid/docs/
- Demo: https://tamb.github.io/game-grid/demo/output.html
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-02a97c48-2e35-4da8-aad8-89e0fad4b2d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-02a97c48-2e35-4da8-aad8-89e0fad4b2d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

