### PR TITLE
Improve TypeDoc docs organization and add API table of contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Browse the [published API reference](https://tamb.github.io/game-grid/docs/) on 
 npm run docs
 ```
 
-HTML lands in **`gh-pages/docs/`** (open **`gh-pages/docs/index.html`** locally).
+HTML lands in **`gh-pages/docs/`** (open **`gh-pages/docs/index.html`** locally). The TypeDoc landing page uses **`docs/API.md`** (overview + table of contents); the full README stays on GitHub.
 
 Combined **demo + docs** bundle for GitHub Pages:
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,0 +1,51 @@
+# GameGrid API reference
+
+**@tamb/gamegrid** — a TypeScript library for 2D grid-based web games and interactive matrices.
+
+**Also see:** [site home](https://tamb.github.io/game-grid/) · [interactive demo](https://tamb.github.io/game-grid/demo/output.html) · [GitHub README](https://github.com/tamb/game-grid#readme)
+
+## Table of contents
+
+Browse the full API on the [**exports index**](modules.html):
+
+| Section | Symbols |
+| --- | --- |
+| [Grid runtime](modules.html#grid-runtime) | [`GameGrid`](classes/GameGrid.html) (default export) |
+| [Grid contract](modules.html#grid-contract) | [`IGameGrid`](interfaces/IGameGrid.html) |
+| [Configuration](modules.html#configuration) | [`IConfig`](interfaces/IConfig.html), [`IOptions`](interfaces/IOptions.html), [`MiddlewareFn`](types/MiddlewareFn.html) |
+| [State](modules.html#state) | [`IState`](interfaces/IState.html), [`StatePatch`](types/StatePatch.html), [`IDefaultState`](interfaces/IDefaultState.html), [`INITIAL_STATE`](variables/INITIAL_STATE.html) |
+| [Data model](modules.html#data-model) | [`ICell`](interfaces/ICell.html), [`ICellContext`](interfaces/ICellContext.html) |
+| [Events](modules.html#events) | [`gridEventsEnum`](variables/gridEventsEnum.html), [`gameGridEventsEnum`](variables/gameGridEventsEnum.html), [`IGameGridEventDetail`](interfaces/IGameGridEventDetail.html), [`GameGridDOMEvent`](types/GameGridDOMEvent.html) |
+| [Zoom](modules.html#zoom) | [`IZoomBounds`](interfaces/IZoomBounds.html), [`IZoomOptions`](interfaces/IZoomOptions.html), [`IRegionTile`](interfaces/IRegionTile.html), [`ZoomQuadrant`](types/ZoomQuadrant.html) |
+| [References](modules.html#references) | [`IRefsObject`](interfaces/IRefsObject.html), [`IRow`](interfaces/IRow.html) |
+| [Cells](modules.html#cells) | [`cellTypeEnum`](variables/cellTypeEnum.html) |
+| [Movement](modules.html#movement) | [`directionEnum`](enums/directionEnum.html) |
+| [Inputs](modules.html#inputs) | [`keycodeEnum`](enums/keycodeEnum.html) |
+| [Presentation](modules.html#presentation) | [`classesEnum`](enums/classesEnum.html), [`directionClassEnum`](variables/directionClassEnum.html) |
+
+## Coordinates
+
+Movement and state use **`[x, y]`**: column (x), then row (y). The backing matrix is `matrix[row][col]` → `matrix[y][x]`.
+
+## Quick start
+
+```ts
+import GameGrid, { gridEventsEnum, type GameGridDOMEvent } from "@tamb/gamegrid";
+
+const grid = new GameGrid(
+  {
+    matrix: myMatrix,
+    state: { activeCoords: [0, 0] },
+    options: { wasdControls: true },
+  },
+  document.querySelector("#root")!,
+);
+
+grid.moveDown();
+window.addEventListener(gridEventsEnum.MOVE_LAND, (e: Event) => {
+  const ce = e as GameGridDOMEvent;
+  console.log(ce.detail.gameGridInstance.getState());
+});
+```
+
+Omit the container argument for headless use, then call `render(element)` when you need DOM.

--- a/src/enums.ts
+++ b/src/enums.ts
@@ -107,7 +107,12 @@ export const directionClassEnum: { [ket: string]: string } = {
   RIGHT: 'gamegrid__direction--right',
 };
 
-/** Default {@link IState} seeded before {@link IConfig.state} merges. Shipped as a named runtime export from the package barrel. */
+/**
+ * Default {@link IState} seeded before {@link IConfig.state} merges.
+ * Shipped as a named runtime export from the package barrel.
+ *
+ * @category State
+ */
 export const INITIAL_STATE: IState = {
   activeCoords: [0, 0],
   prevCoords: [0, 0],

--- a/src/index.ts
+++ b/src/index.ts
@@ -74,6 +74,8 @@ export type {
 
 /**
  * Compatibility alias exporting the identical object references as {@link gridEventsEnum}.
+ *
+ * @category Events
  */
 export const gameGridEventsEnum = gridEventsEnum;
 

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1,4 +1,8 @@
-/** Inclusive axis-aligned zoom window in world coordinates. */
+/**
+ * Inclusive axis-aligned zoom window in world coordinates.
+ *
+ * @category Zoom
+ */
 export interface IZoomBounds {
   minX: number;
   minY: number;
@@ -6,13 +10,21 @@ export interface IZoomBounds {
   maxY: number;
 }
 
-/** Per-call overrides for {@link GameGrid.setZoom} / {@link GameGrid.clearZoom} / convenience zoom methods. */
+/**
+ * Per-call overrides for {@link GameGrid.setZoom} / {@link GameGrid.clearZoom} / convenience zoom methods.
+ *
+ * @category Zoom
+ */
 export interface IZoomOptions {
   /** Overrides {@link IOptions.animateZoom} for this call only. */
   animate?: boolean;
 }
 
-/** A fraction/quadrant tile index within the full grid. */
+/**
+ * A fraction/quadrant tile index within the full grid.
+ *
+ * @category Zoom
+ */
 export interface IRegionTile {
   divisions: number;
   tileX: number;
@@ -21,9 +33,18 @@ export interface IRegionTile {
   quadrant?: ZoomQuadrant;
 }
 
+/**
+ * Cardinal quadrant label when {@link IRegionTile.divisions} is `2`.
+ *
+ * @category Zoom
+ */
 export type ZoomQuadrant = 'nw' | 'ne' | 'sw' | 'se';
 
-/** `activeCoords`, `prevCoords`, and cell `coords` use `[x, y]` → column, then row (`matrix[row][col]` → `matrix[y][x]`). */
+/**
+ * `activeCoords`, `prevCoords`, and cell `coords` use `[x, y]` → column, then row (`matrix[row][col]` → `matrix[y][x]`).
+ *
+ * @category State
+ */
 export interface IState {
   /** Current focus column `x`, then row `y`. Same order as {@link GameGrid.setActiveCell}. */
   activeCoords: number[];
@@ -49,6 +70,8 @@ export interface IState {
  * ```ts
  * grid.setStateSync({ activeCoords: [1, 2], myMeta: true });
  * ```
+ *
+ * @category State
  */
 export type StatePatch = Partial<IState> & Record<string, unknown>;
 
@@ -71,7 +94,11 @@ export interface IGameGridEventDetail extends Record<string, unknown> {
  */
 export type GameGridDOMEvent = CustomEvent<IGameGridEventDetail>;
 
-/** Allowed fields when merging initial grid {@link GameGrid} state. */
+/**
+ * Allowed fields when merging initial grid {@link GameGrid} state.
+ *
+ * @category State
+ */
 export interface IDefaultState {
   activeCoords?: number[];
   prevCoords?: number[];
@@ -407,7 +434,11 @@ export interface ICell extends IRef {
   coords?: number[];
 }
 
-/** Describes a rendered row plus associated {@link ICell} metadata. */
+/**
+ * Describes a rendered row plus associated {@link ICell} metadata.
+ *
+ * @category References
+ */
 export interface IRow extends IRef {
   index: number;
   cells: ICell[];
@@ -424,5 +455,9 @@ export interface IRefsObject {
   cells: ICell[][];
 }
 
-/** @deprecated Use {@link IRefsObject}; identical alias retained for transitional typings. */
+/**
+ * @deprecated Use {@link IRefsObject}; identical alias retained for transitional typings.
+ *
+ * @category References
+ */
 export type IRefs = IRefsObject;

--- a/typedoc.json
+++ b/typedoc.json
@@ -2,15 +2,37 @@
   "$schema": "https://typedoc.org/schema.json",
   "entryPoints": ["src/index.ts"],
   "tsconfig": "./tsconfig.typedoc.json",
-  "readme": "./README.md",
+  "readme": "./docs/API.md",
   "name": "@tamb/gamegrid",
   "out": "./gh-pages/docs",
   "githubPages": true,
   "excludePrivate": true,
   "excludeProtected": true,
   "excludeInternal": true,
+  "excludeReferences": true,
   "searchInComments": true,
+  "groupReferencesByType": true,
+  "categoryOrder": [
+    "Grid runtime",
+    "Grid contract",
+    "Configuration",
+    "State",
+    "Data model",
+    "Events",
+    "Zoom",
+    "References",
+    "Cells",
+    "Movement",
+    "Inputs",
+    "Presentation",
+    "*"
+  ],
   "navigation": {
     "includeCategories": true
+  },
+  "navigationLinks": {
+    "Site home": "../",
+    "Demos": "../demo/output.html",
+    "GitHub": "https://github.com/tamb/game-grid"
   }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Cleans up the generated TypeDoc site so the public API is easier to browse:

- **New `docs/API.md` landing page** — replaces the full repo README on the docs index with a concise overview, quick-start snippet, and a **table of contents** linking to each API section and symbol.
- **Better category grouping** — adds `@category` tags for state, zoom, and reference types (`IState`, `IZoomBounds`, `IRow`, etc.) so they no longer land in a catch-all "Other" bucket.
- **TypeDoc config updates** (`typedoc.json`):
  - Logical `categoryOrder` (Grid runtime → contract → configuration → state → …)
  - Header links to site home, demos, and GitHub
  - `excludeReferences` to drop the duplicate `default → GameGrid` entry

## Result

The exports index (`modules.html`) now lists symbols in a sensible order with dedicated sections for **State** and **Zoom**, and the docs home page has an "On This Page" sidebar TOC plus the new section table.

## Test plan

- [x] `npm run docs` — generates without errors (link warnings in `docs/API.md` are expected; links resolve in output)
- [x] `npm run check`
- [x] `npm run test`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ae3dad9a-6ff9-4470-947a-6f72ac3736db"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ae3dad9a-6ff9-4470-947a-6f72ac3736db"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

