### PR TITLE
Fix demo grid overflow from container padding on mobile

### DIFF
--- a/demo/src/styles/styles.scss
+++ b/demo/src/styles/styles.scss
@@ -13,6 +13,8 @@
 }
 
 .site-body--demo {
+  margin: 0;
+  overflow-x: clip;
   background:
     radial-gradient(ellipse 70% 40% at 50% -10%, rgba(56, 189, 248, 0.12), transparent),
     linear-gradient(180deg, #0f1623 0%, var(--gg-bg) 38%);
@@ -317,7 +319,7 @@
   overflow: auto;
 }
 
-/* Mobile: grid 85vw with 7vw side controls (99vw total) */
+/* Mobile: grid 99vw with 7vw side controls; break out of container padding */
 @media (max-width: 1199.98px) {
   .demo-grid-wrap {
     display: grid;
@@ -332,8 +334,8 @@
     justify-items: stretch;
     width: 99vw;
     max-width: 99vw;
-    margin-left: auto;
-    margin-right: auto;
+    margin-left: calc(50% - 49.5vw);
+    margin-right: calc(50% - 49.5vw);
     overflow: visible;
   }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes horizontal overflow in the interactive demo grids on smaller viewports.

The mobile layout sizes `.demo-grid-wrap` at `99vw` (7vw controls + 85vw grid + 7vw controls), but that element sits inside Bootstrap `container-fluid` / column padding. Because `vw` is viewport-relative, the extra parent padding made the layout wider than the screen.

## Changes

- Center the mobile grid shell in the viewport with `margin-left/right: calc(50% - 49.5vw)` so it breaks out of padded containers
- Set `margin: 0` and `overflow-x: clip` on `.site-body--demo` to prevent stray horizontal scroll

## Test plan

- [x] `npm run check`
- [ ] Open demo on a narrow viewport and confirm grids + d-pad fit without horizontal page scroll
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ae3dad9a-6ff9-4470-947a-6f72ac3736db"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ae3dad9a-6ff9-4470-947a-6f72ac3736db"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

