### PR TITLE
chore(release): prepare 1.0.0 with CI, metadata, and UMD fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: npm
+          cache-dependency-path: package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Test, build, and lint
+        run: |
+          npm run build.safe
+          npm run check

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,56 @@
+# Changelog
+
+All notable changes to `@tamb/gamegrid` are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.0.0] - 2026-07-29
+
+First stable release.
+
+### Added
+
+- CI workflow running tests, build, and Biome lint on pushes and pull requests to `main`.
+- `CHANGELOG.md` and complete `package.json` metadata (`description`, `author`, `keywords`, `repository`, `bugs`).
+- UMD bundle entry (`src/umd-entry.ts`) so script-tag consumers get `GameGrid` as the constructor with named exports attached (no `.default` accessor).
+
+### Changed
+
+- Promoted `1.0.0-rc.0` to stable `1.0.0`.
+
+## [1.0.0-rc.0] - 2026-07-25
+
+Release candidate with zoom viewport API, toolchain modernization, and expanded test coverage.
+
+### Added
+
+- **Zoom API**: viewport windows (`setZoom`, `clearZoom`, `zoomQuadrant`, `zoomFraction`, `zoomAround`), region tracking (`regionDivisions`), zoom edge/exit events, and optional CSS slide transitions (`animateZoom`, `slideZoomOnEdge`).
+- **Toolchain**: Vitest, Biome, Rolldown (replacing Rollup), TypeDoc docs, and GitHub Pages demo + API reference.
+- **State API**: `setStateSync` for shallow state patches with middleware `pre`/`post` hooks.
+- **Options**: `eventTarget`, custom CSS class arrays, `moveOnType` allow-list, `constrainToZoom`, `zoomSlideDuration`, `zoomViewportClasses`.
+- **Lifecycle**: `destroy()` tears down listeners/DOM and emits `DESTROYED`; `refresh()` rebuilds DOM from the current matrix.
+- **Publishing**: `.npmrc.example` for scoped npm publish; `safe.publish` script.
+- Demo mobile controls, zoom maze pane, and redesigned GitHub Pages landing page.
+
+### Fixed
+
+- Blocked cells bypassed at zoom edges ([#46](https://github.com/tamb/game-grid/pull/46)).
+- Missing `reservedCellAttributes` set lost in zoom merge ([#45](https://github.com/tamb/game-grid/pull/45)).
+- Coin maze regenerate listener leak and cell attribute hardening ([#43](https://github.com/tamb/game-grid/pull/43)).
+- Container references for headless grids when rendering later ([#39](https://github.com/tamb/game-grid/pull/39)).
+- Callback order regression on `getActiveCell` ([#37](https://github.com/tamb/game-grid/pull/37)).
+- `onLand` only fires when the active cell actually changes ([#33](https://github.com/tamb/game-grid/pull/33)).
+
+### Changed
+
+- `setActiveCell` is public.
+- Build output uses Rolldown (`dist/main.js` ESM + `dist/main.umd.js` UMD).
+
+## [1.0.0-beta.6] - 2024-01-21
+
+Last beta before the zoom and toolchain work above. See git history between `v1.0.0-beta.6` and `v1.0.0-rc.0` for incremental beta releases (beta.7–beta.16 on npm).
+
+[1.0.0]: https://github.com/tamb/game-grid/compare/v1.0.0-rc.0...v1.0.0
+[1.0.0-rc.0]: https://github.com/tamb/game-grid/compare/v1.0.0-beta.6...v1.0.0-rc.0
+[1.0.0-beta.6]: https://github.com/tamb/game-grid/releases/tag/v1.0.0-beta.6

--- a/demo/package-lock.json
+++ b/demo/package-lock.json
@@ -1153,9 +1153,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1177,9 +1174,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1201,9 +1195,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1225,9 +1216,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1730,9 +1718,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1754,9 +1739,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1778,9 +1760,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1802,9 +1781,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1826,9 +1802,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1850,9 +1823,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2043,9 +2013,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -2063,9 +2030,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -2083,9 +2047,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -2103,9 +2064,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -2123,9 +2081,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -2143,9 +2098,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -2717,9 +2669,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2741,9 +2690,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2765,9 +2711,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2789,9 +2732,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tamb/gamegrid",
-  "version": "1.0.0-rc.0",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tamb/gamegrid",
-      "version": "1.0.0-rc.0",
+      "version": "1.0.0",
       "license": "MIT",
       "devDependencies": {
         "@biomejs/biome": "^2.4.14",
@@ -199,9 +199,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -219,9 +216,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -239,9 +233,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -259,9 +250,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -677,9 +665,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -697,9 +682,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -717,9 +699,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -737,9 +716,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -757,9 +733,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -777,9 +750,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1627,9 +1597,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1651,9 +1618,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1675,9 +1639,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1699,9 +1660,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2521,9 +2479,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2541,9 +2496,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2561,9 +2513,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2581,9 +2530,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2601,9 +2547,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2621,9 +2564,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tamb/gamegrid",
-  "version": "1.0.0-rc.0",
-  "description": "",
+  "version": "1.0.0",
+  "description": "A 2D HTML grid for creating web games (or other things that could use a 2D matrix)",
   "homepage": "https://tamb.github.io/game-grid/docs/",
   "main": "dist/main.js",
   "source": "src/index.ts",
@@ -15,14 +15,16 @@
     "test:coverage": "vitest run --coverage",
     "test.watch": "vitest",
     "build": "rolldown -c rolldown.config.mjs && tsc -p tsconfig.build.json",
-    "build.safe": "npm run test && npm run build",
+    "build.safe": "npm run test && npm run build && npm run test:dist",
+    "test:dist": "vitest run --config vitest.dist.config.ts",
     "dev": "rolldown -c rolldown.config.mjs -w",
     "lint": "biome check --write",
     "format": "biome format --write .",
     "check": "biome check .",
     "docs": "typedoc",
     "gh-pages": "node scripts/prepare-gh-pages.js && npm run build && npm run demo:install && npm run docs && node scripts/build-demo-gh-pages.js",
-    "safe.publish": "npm run build.safe && npm publish",
+    "safe.publish": "npm run build.safe && npm publish --access public",
+    "publish:prod": "npm run build.safe && npm publish --access public && npm dist-tag add @tamb/gamegrid@$npm_package_version latest",
     "demo:clean": "npm run clean && npm --prefix demo run clean",
     "demo:install": "npm --prefix demo install",
     "demo:compile": "npm --prefix demo run compile",
@@ -38,9 +40,26 @@
     "start": "npm run demo:start",
     "link:lib": "npm run demo:link:lib"
   },
-  "keywords": [],
-  "author": "",
+  "keywords": [
+    "grid",
+    "game",
+    "2d",
+    "matrix",
+    "typescript",
+    "dom",
+    "html",
+    "web-game",
+    "game-grid"
+  ],
+  "author": "¡Támb!",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/tamb/game-grid.git"
+  },
+  "bugs": {
+    "url": "https://github.com/tamb/game-grid/issues"
+  },
   "devDependencies": {
     "@biomejs/biome": "^2.4.14",
     "@types/node": "^25.2.14",

--- a/rolldown.config.mjs
+++ b/rolldown.config.mjs
@@ -2,11 +2,12 @@ import { defineConfig } from 'rolldown';
 
 export default defineConfig([
   {
-    input: 'src/index.ts',
+    input: 'src/umd-entry.ts',
     output: {
       file: 'dist/main.umd.js',
       format: 'umd',
       name: 'GameGrid',
+      exports: 'default',
       sourcemap: true,
       minify: true,
     },

--- a/src/__tests__/umd-bundle.dist.test.ts
+++ b/src/__tests__/umd-bundle.dist.test.ts
@@ -1,0 +1,23 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import vm from 'node:vm';
+
+const umdPath = resolve(import.meta.dirname, '../../dist/main.umd.js');
+
+describe('UMD bundle', () => {
+  if (!existsSync(umdPath)) {
+    it.skip('requires dist/main.umd.js (run npm run build first)', () => {});
+    return;
+  }
+
+  it('exposes the GameGrid constructor and named exports without .default', () => {
+    const umd = readFileSync(umdPath, 'utf8');
+    const sandbox: { GameGrid?: Record<string, unknown> & (new () => unknown) } = {};
+    vm.runInNewContext(umd, sandbox, { filename: 'main.umd.js' });
+
+    expect(typeof sandbox.GameGrid).toBe('function');
+    expect(sandbox.GameGrid).toHaveProperty('gridEventsEnum');
+    expect(sandbox.GameGrid).toHaveProperty('cellTypeEnum');
+    expect(sandbox.GameGrid).not.toHaveProperty('default');
+  });
+});

--- a/src/umd-entry.ts
+++ b/src/umd-entry.ts
@@ -1,0 +1,27 @@
+/**
+ * UMD bundle entry: attaches named exports to the default {@link GameGrid} class
+ * so script-tag consumers can use `new GameGrid()` and `GameGrid.gridEventsEnum`
+ * without a `.default` accessor.
+ */
+import GameGrid, {
+  cellTypeEnum,
+  classesEnum,
+  directionClassEnum,
+  directionEnum,
+  gameGridEventsEnum,
+  gridEventsEnum,
+  INITIAL_STATE,
+  keycodeEnum,
+} from './index';
+
+export default Object.assign(GameGrid, {
+  GameGrid,
+  cellTypeEnum,
+  classesEnum,
+  directionClassEnum,
+  directionEnum,
+  gameGridEventsEnum,
+  gridEventsEnum,
+  INITIAL_STATE,
+  keycodeEnum,
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,5 +5,6 @@ export default defineConfig({
     globals: true,
     environment: 'jsdom',
     include: ['src/**/__tests__/**/*.ts'],
+    exclude: ['src/**/__tests__/**/*.dist.test.ts'],
   },
 });

--- a/vitest.dist.config.ts
+++ b/vitest.dist.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['src/**/__tests__/**/*.dist.test.ts'],
+  },
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Completes the production-release checklist for `@tamb/gamegrid` 1.0.0:

- **CI** — new `.github/workflows/ci.yml` runs `npm run build.safe` and `npm run check` on pushes and PRs to `main`
- **Package metadata** — `description`, `author`, `keywords`, `repository`, and `bugs` fields in `package.json`
- **CHANGELOG** — documents changes from `1.0.0-beta.6` through `1.0.0`
- **UMD fix** — dedicated `src/umd-entry.ts` with `exports: 'default'` so script-tag consumers get `GameGrid` as the constructor with named exports attached (no `.default` accessor); post-build smoke test included
- **Version bump** — `1.0.0-rc.0` → `1.0.0`

## Publishing (manual step after merge)

This PR does not publish to npm. After merge and tag:

```bash
npm run publish:prod
```

That runs tests + build, publishes with `--access public`, and sets the `latest` dist-tag (currently `latest` points at `1.0.0-beta.16`).

## Test plan

- [x] `npm run build.safe` — 151 unit tests + 1 UMD dist test pass
- [x] `npm run check` — Biome clean
- [x] Rolldown build completes without `MIXED_EXPORTS` warning
- [x] UMD global exposes `GameGrid` as a function with `gridEventsEnum` attached

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a9d3e5ff-925d-4866-b9ee-7ed23a5acad0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a9d3e5ff-925d-4866-b9ee-7ed23a5acad0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

