### PR TITLE
Fix mobile demo layout: dpad row below grid

### DIFF
--- a/demo/src/output.html
+++ b/demo/src/output.html
@@ -169,16 +169,16 @@
         >
           <button
             type='button'
-            class='btn gamegrid-dpad-btn gamegrid-dpad-btn--up'
-            data-gamegrid-move='up'
-            aria-label='Move up'
-          >↑</button>
-          <button
-            type='button'
             class='btn gamegrid-dpad-btn gamegrid-dpad-btn--left'
             data-gamegrid-move='left'
             aria-label='Move left'
           >←</button>
+          <button
+            type='button'
+            class='btn gamegrid-dpad-btn gamegrid-dpad-btn--up'
+            data-gamegrid-move='up'
+            aria-label='Move up'
+          >↑</button>
           <button
             type='button'
             class='btn gamegrid-dpad-btn gamegrid-dpad-btn--right'
@@ -208,16 +208,16 @@
         >
           <button
             type='button'
-            class='btn gamegrid-dpad-btn gamegrid-dpad-btn--up'
-            data-gamegrid-move='up'
-            aria-label='Move up'
-          >↑</button>
-          <button
-            type='button'
             class='btn gamegrid-dpad-btn gamegrid-dpad-btn--left'
             data-gamegrid-move='left'
             aria-label='Move left'
           >←</button>
+          <button
+            type='button'
+            class='btn gamegrid-dpad-btn gamegrid-dpad-btn--up'
+            data-gamegrid-move='up'
+            aria-label='Move up'
+          >↑</button>
           <button
             type='button'
             class='btn gamegrid-dpad-btn gamegrid-dpad-btn--right'
@@ -269,16 +269,16 @@
         >
           <button
             type='button'
-            class='btn gamegrid-dpad-btn gamegrid-dpad-btn--up'
-            data-gamegrid-move='up'
-            aria-label='Move up'
-          >↑</button>
-          <button
-            type='button'
             class='btn gamegrid-dpad-btn gamegrid-dpad-btn--left'
             data-gamegrid-move='left'
             aria-label='Move left'
           >←</button>
+          <button
+            type='button'
+            class='btn gamegrid-dpad-btn gamegrid-dpad-btn--up'
+            data-gamegrid-move='up'
+            aria-label='Move up'
+          >↑</button>
           <button
             type='button'
             class='btn gamegrid-dpad-btn gamegrid-dpad-btn--right'
@@ -325,16 +325,16 @@
         >
           <button
             type='button'
-            class='btn gamegrid-dpad-btn gamegrid-dpad-btn--up'
-            data-gamegrid-move='up'
-            aria-label='Move up'
-          >↑</button>
-          <button
-            type='button'
             class='btn gamegrid-dpad-btn gamegrid-dpad-btn--left'
             data-gamegrid-move='left'
             aria-label='Move left'
           >←</button>
+          <button
+            type='button'
+            class='btn gamegrid-dpad-btn gamegrid-dpad-btn--up'
+            data-gamegrid-move='up'
+            aria-label='Move up'
+          >↑</button>
           <button
             type='button'
             class='btn gamegrid-dpad-btn gamegrid-dpad-btn--right'
@@ -393,16 +393,16 @@
         >
           <button
             type='button'
-            class='btn gamegrid-dpad-btn gamegrid-dpad-btn--up'
-            data-gamegrid-move='up'
-            aria-label='Move up'
-          >↑</button>
-          <button
-            type='button'
             class='btn gamegrid-dpad-btn gamegrid-dpad-btn--left'
             data-gamegrid-move='left'
             aria-label='Move left'
           >←</button>
+          <button
+            type='button'
+            class='btn gamegrid-dpad-btn gamegrid-dpad-btn--up'
+            data-gamegrid-move='up'
+            aria-label='Move up'
+          >↑</button>
           <button
             type='button'
             class='btn gamegrid-dpad-btn gamegrid-dpad-btn--right'
@@ -443,16 +443,16 @@
         >
           <button
             type='button'
-            class='btn gamegrid-dpad-btn gamegrid-dpad-btn--up'
-            data-gamegrid-move='up'
-            aria-label='Move up'
-          >↑</button>
-          <button
-            type='button'
             class='btn gamegrid-dpad-btn gamegrid-dpad-btn--left'
             data-gamegrid-move='left'
             aria-label='Move left'
           >←</button>
+          <button
+            type='button'
+            class='btn gamegrid-dpad-btn gamegrid-dpad-btn--up'
+            data-gamegrid-move='up'
+            aria-label='Move up'
+          >↑</button>
           <button
             type='button'
             class='btn gamegrid-dpad-btn gamegrid-dpad-btn--right'

--- a/demo/src/output.html
+++ b/demo/src/output.html
@@ -169,25 +169,25 @@
         >
           <button
             type='button'
-            class='btn btn-outline-primary gamegrid-dpad-btn gamegrid-dpad-btn--up'
+            class='btn gamegrid-dpad-btn gamegrid-dpad-btn--up'
             data-gamegrid-move='up'
             aria-label='Move up'
           >↑</button>
           <button
             type='button'
-            class='btn btn-outline-primary gamegrid-dpad-btn gamegrid-dpad-btn--left'
+            class='btn gamegrid-dpad-btn gamegrid-dpad-btn--left'
             data-gamegrid-move='left'
             aria-label='Move left'
           >←</button>
           <button
             type='button'
-            class='btn btn-outline-primary gamegrid-dpad-btn gamegrid-dpad-btn--right'
+            class='btn gamegrid-dpad-btn gamegrid-dpad-btn--right'
             data-gamegrid-move='right'
             aria-label='Move right'
           >→</button>
           <button
             type='button'
-            class='btn btn-outline-primary gamegrid-dpad-btn gamegrid-dpad-btn--down'
+            class='btn gamegrid-dpad-btn gamegrid-dpad-btn--down'
             data-gamegrid-move='down'
             aria-label='Move down'
           >↓</button>
@@ -208,25 +208,25 @@
         >
           <button
             type='button'
-            class='btn btn-outline-primary gamegrid-dpad-btn gamegrid-dpad-btn--up'
+            class='btn gamegrid-dpad-btn gamegrid-dpad-btn--up'
             data-gamegrid-move='up'
             aria-label='Move up'
           >↑</button>
           <button
             type='button'
-            class='btn btn-outline-primary gamegrid-dpad-btn gamegrid-dpad-btn--left'
+            class='btn gamegrid-dpad-btn gamegrid-dpad-btn--left'
             data-gamegrid-move='left'
             aria-label='Move left'
           >←</button>
           <button
             type='button'
-            class='btn btn-outline-primary gamegrid-dpad-btn gamegrid-dpad-btn--right'
+            class='btn gamegrid-dpad-btn gamegrid-dpad-btn--right'
             data-gamegrid-move='right'
             aria-label='Move right'
           >→</button>
           <button
             type='button'
-            class='btn btn-outline-primary gamegrid-dpad-btn gamegrid-dpad-btn--down'
+            class='btn gamegrid-dpad-btn gamegrid-dpad-btn--down'
             data-gamegrid-move='down'
             aria-label='Move down'
           >↓</button>
@@ -269,25 +269,25 @@
         >
           <button
             type='button'
-            class='btn btn-outline-primary gamegrid-dpad-btn gamegrid-dpad-btn--up'
+            class='btn gamegrid-dpad-btn gamegrid-dpad-btn--up'
             data-gamegrid-move='up'
             aria-label='Move up'
           >↑</button>
           <button
             type='button'
-            class='btn btn-outline-primary gamegrid-dpad-btn gamegrid-dpad-btn--left'
+            class='btn gamegrid-dpad-btn gamegrid-dpad-btn--left'
             data-gamegrid-move='left'
             aria-label='Move left'
           >←</button>
           <button
             type='button'
-            class='btn btn-outline-primary gamegrid-dpad-btn gamegrid-dpad-btn--right'
+            class='btn gamegrid-dpad-btn gamegrid-dpad-btn--right'
             data-gamegrid-move='right'
             aria-label='Move right'
           >→</button>
           <button
             type='button'
-            class='btn btn-outline-primary gamegrid-dpad-btn gamegrid-dpad-btn--down'
+            class='btn gamegrid-dpad-btn gamegrid-dpad-btn--down'
             data-gamegrid-move='down'
             aria-label='Move down'
           >↓</button>
@@ -325,25 +325,25 @@
         >
           <button
             type='button'
-            class='btn btn-outline-primary gamegrid-dpad-btn gamegrid-dpad-btn--up'
+            class='btn gamegrid-dpad-btn gamegrid-dpad-btn--up'
             data-gamegrid-move='up'
             aria-label='Move up'
           >↑</button>
           <button
             type='button'
-            class='btn btn-outline-primary gamegrid-dpad-btn gamegrid-dpad-btn--left'
+            class='btn gamegrid-dpad-btn gamegrid-dpad-btn--left'
             data-gamegrid-move='left'
             aria-label='Move left'
           >←</button>
           <button
             type='button'
-            class='btn btn-outline-primary gamegrid-dpad-btn gamegrid-dpad-btn--right'
+            class='btn gamegrid-dpad-btn gamegrid-dpad-btn--right'
             data-gamegrid-move='right'
             aria-label='Move right'
           >→</button>
           <button
             type='button'
-            class='btn btn-outline-primary gamegrid-dpad-btn gamegrid-dpad-btn--down'
+            class='btn gamegrid-dpad-btn gamegrid-dpad-btn--down'
             data-gamegrid-move='down'
             aria-label='Move down'
           >↓</button>
@@ -393,25 +393,25 @@
         >
           <button
             type='button'
-            class='btn btn-outline-primary gamegrid-dpad-btn gamegrid-dpad-btn--up'
+            class='btn gamegrid-dpad-btn gamegrid-dpad-btn--up'
             data-gamegrid-move='up'
             aria-label='Move up'
           >↑</button>
           <button
             type='button'
-            class='btn btn-outline-primary gamegrid-dpad-btn gamegrid-dpad-btn--left'
+            class='btn gamegrid-dpad-btn gamegrid-dpad-btn--left'
             data-gamegrid-move='left'
             aria-label='Move left'
           >←</button>
           <button
             type='button'
-            class='btn btn-outline-primary gamegrid-dpad-btn gamegrid-dpad-btn--right'
+            class='btn gamegrid-dpad-btn gamegrid-dpad-btn--right'
             data-gamegrid-move='right'
             aria-label='Move right'
           >→</button>
           <button
             type='button'
-            class='btn btn-outline-primary gamegrid-dpad-btn gamegrid-dpad-btn--down'
+            class='btn gamegrid-dpad-btn gamegrid-dpad-btn--down'
             data-gamegrid-move='down'
             aria-label='Move down'
           >↓</button>
@@ -443,25 +443,25 @@
         >
           <button
             type='button'
-            class='btn btn-outline-primary gamegrid-dpad-btn gamegrid-dpad-btn--up'
+            class='btn gamegrid-dpad-btn gamegrid-dpad-btn--up'
             data-gamegrid-move='up'
             aria-label='Move up'
           >↑</button>
           <button
             type='button'
-            class='btn btn-outline-primary gamegrid-dpad-btn gamegrid-dpad-btn--left'
+            class='btn gamegrid-dpad-btn gamegrid-dpad-btn--left'
             data-gamegrid-move='left'
             aria-label='Move left'
           >←</button>
           <button
             type='button'
-            class='btn btn-outline-primary gamegrid-dpad-btn gamegrid-dpad-btn--right'
+            class='btn gamegrid-dpad-btn gamegrid-dpad-btn--right'
             data-gamegrid-move='right'
             aria-label='Move right'
           >→</button>
           <button
             type='button'
-            class='btn btn-outline-primary gamegrid-dpad-btn gamegrid-dpad-btn--down'
+            class='btn gamegrid-dpad-btn gamegrid-dpad-btn--down'
             data-gamegrid-move='down'
             aria-label='Move down'
           >↓</button>

--- a/demo/src/partials/touchpad.hbs
+++ b/demo/src/partials/touchpad.hbs
@@ -5,16 +5,16 @@
 >
   <button
     type='button'
-    class='btn gamegrid-dpad-btn gamegrid-dpad-btn--up'
-    data-gamegrid-move='up'
-    aria-label='Move up'
-  >↑</button>
-  <button
-    type='button'
     class='btn gamegrid-dpad-btn gamegrid-dpad-btn--left'
     data-gamegrid-move='left'
     aria-label='Move left'
   >←</button>
+  <button
+    type='button'
+    class='btn gamegrid-dpad-btn gamegrid-dpad-btn--up'
+    data-gamegrid-move='up'
+    aria-label='Move up'
+  >↑</button>
   <button
     type='button'
     class='btn gamegrid-dpad-btn gamegrid-dpad-btn--right'

--- a/demo/src/partials/touchpad.hbs
+++ b/demo/src/partials/touchpad.hbs
@@ -5,25 +5,25 @@
 >
   <button
     type='button'
-    class='btn btn-outline-primary gamegrid-dpad-btn gamegrid-dpad-btn--up'
+    class='btn gamegrid-dpad-btn gamegrid-dpad-btn--up'
     data-gamegrid-move='up'
     aria-label='Move up'
   >↑</button>
   <button
     type='button'
-    class='btn btn-outline-primary gamegrid-dpad-btn gamegrid-dpad-btn--left'
+    class='btn gamegrid-dpad-btn gamegrid-dpad-btn--left'
     data-gamegrid-move='left'
     aria-label='Move left'
   >←</button>
   <button
     type='button'
-    class='btn btn-outline-primary gamegrid-dpad-btn gamegrid-dpad-btn--right'
+    class='btn gamegrid-dpad-btn gamegrid-dpad-btn--right'
     data-gamegrid-move='right'
     aria-label='Move right'
   >→</button>
   <button
     type='button'
-    class='btn btn-outline-primary gamegrid-dpad-btn gamegrid-dpad-btn--down'
+    class='btn gamegrid-dpad-btn gamegrid-dpad-btn--down'
     data-gamegrid-move='down'
     aria-label='Move down'
   >↓</button>

--- a/demo/src/styles/styles.scss
+++ b/demo/src/styles/styles.scss
@@ -319,44 +319,44 @@
   overflow: auto;
 }
 
-/* Mobile: grid 99vw with 7vw side controls; break out of container padding */
+/* Mobile / tablet: dpad around grid within the column (no viewport breakout) */
 @media (max-width: 1199.98px) {
   .demo-grid-wrap {
     display: grid;
-    grid-template-columns: 7vw 85vw 7vw;
+    grid-template-columns: minmax(2.75rem, 12%) 1fr minmax(2.75rem, 12%);
     grid-template-rows: auto minmax(0, 1fr) auto;
     grid-template-areas:
       '. up .'
       'left grid right'
       '. down .';
-    gap: 0;
+    gap: 0.25rem;
     align-items: stretch;
     justify-items: stretch;
-    width: 99vw;
-    max-width: 99vw;
-    margin-left: calc(50% - 49.5vw);
-    margin-right: calc(50% - 49.5vw);
+    width: 100%;
+    max-width: 100%;
+    margin-left: 0;
+    margin-right: 0;
     overflow: visible;
   }
 
   .demo-grid-wrap--tall {
-    width: 99vw;
-    max-width: 99vw;
+    width: 100%;
+    max-width: 100%;
     max-height: none;
     overflow: visible;
   }
 
   .demo-grid-wrap--zoom {
-    width: 99vw;
-    max-width: 99vw;
+    width: 100%;
+    max-width: 100%;
     max-height: none;
     overflow: visible;
   }
 
   .demo-grid-wrap > .demo-grid-mount {
     grid-area: grid;
-    width: 85vw;
-    max-width: 85vw;
+    width: 100%;
+    max-width: 100%;
     min-width: 0;
     min-height: 0;
     overflow: auto;
@@ -364,11 +364,11 @@
   }
 
   .demo-grid-wrap--tall > .demo-grid-mount {
-    max-height: min(70vh, 85vw);
+    max-height: min(70vh, 100%);
   }
 
   .demo-grid-wrap--zoom > .demo-grid-mount {
-    max-height: min(55vh, 85vw);
+    max-height: min(55vh, 100%);
   }
 
   .demo-grid-wrap .gamegrid-touch-controls {
@@ -444,6 +444,18 @@ $zoom-quadrant-se: #f9a8d4;
   font-size: 1.25rem;
   line-height: 1;
   padding: 0.35rem 0.5rem;
+  box-sizing: border-box;
+  background-color: var(--gg-surface);
+  border: 2px solid var(--gg-accent);
+  color: var(--gg-accent);
+}
+
+.site-body--demo .gamegrid-dpad-btn:hover,
+.site-body--demo .gamegrid-dpad-btn:focus-visible,
+.site-body--demo .gamegrid-dpad-btn:active {
+  background-color: var(--gg-surface-hover);
+  border-color: var(--gg-accent-strong);
+  color: var(--gg-accent);
 }
 
 @media (max-width: 1199.98px) {
@@ -457,30 +469,26 @@ $zoom-quadrant-se: #f9a8d4;
   .gamegrid-dpad-btn--up {
     grid-area: up;
     justify-self: stretch;
-    width: 85vw;
-    max-width: 85vw;
+    width: 100%;
   }
 
   .gamegrid-dpad-btn--left {
     grid-area: left;
     align-self: stretch;
-    width: 7vw;
-    max-width: 7vw;
+    width: 100%;
     height: 100%;
   }
 
   .gamegrid-dpad-btn--right {
     grid-area: right;
     align-self: stretch;
-    width: 7vw;
-    max-width: 7vw;
+    width: 100%;
     height: 100%;
   }
 
   .gamegrid-dpad-btn--down {
     grid-area: down;
     justify-self: stretch;
-    width: 85vw;
-    max-width: 85vw;
+    width: 100%;
   }
 }

--- a/demo/src/styles/styles.scss
+++ b/demo/src/styles/styles.scss
@@ -301,6 +301,9 @@
 
 /* Grids stay within the viewport; inner cells remain %-based */
 .demo-grid-wrap {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
   width: 100%;
   max-width: min(100%, 520px);
   overflow-x: auto;
@@ -319,48 +322,20 @@
   overflow: auto;
 }
 
-/* Mobile / tablet: dpad around grid within the column (no viewport breakout) */
 @media (max-width: 1199.98px) {
   .demo-grid-wrap {
-    display: grid;
-    grid-template-columns: minmax(2.75rem, 12%) 1fr minmax(2.75rem, 12%);
-    grid-template-rows: auto minmax(0, 1fr) auto;
-    grid-template-areas:
-      '. up .'
-      'left grid right'
-      '. down .';
-    gap: 0.25rem;
-    align-items: stretch;
-    justify-items: stretch;
     width: 100%;
     max-width: 100%;
-    margin-left: 0;
-    margin-right: 0;
-    overflow: visible;
   }
 
   .demo-grid-wrap--tall {
-    width: 100%;
     max-width: 100%;
     max-height: none;
-    overflow: visible;
   }
 
   .demo-grid-wrap--zoom {
-    width: 100%;
     max-width: 100%;
     max-height: none;
-    overflow: visible;
-  }
-
-  .demo-grid-wrap > .demo-grid-mount {
-    grid-area: grid;
-    width: 100%;
-    max-width: 100%;
-    min-width: 0;
-    min-height: 0;
-    overflow: auto;
-    -webkit-overflow-scrolling: touch;
   }
 
   .demo-grid-wrap--tall > .demo-grid-mount {
@@ -369,10 +344,6 @@
 
   .demo-grid-wrap--zoom > .demo-grid-mount {
     max-height: min(55vh, 100%);
-  }
-
-  .demo-grid-wrap .gamegrid-touch-controls {
-    display: contents;
   }
 }
 
@@ -432,63 +403,41 @@ $zoom-quadrant-se: #f9a8d4;
   min-width: 0;
 }
 
+.demo-grid-mount {
+  min-width: 0;
+  width: 100%;
+}
+
 .gamegrid-touch-controls {
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  align-items: center;
+  gap: 0.5rem;
+  margin-top: 0.75rem;
   touch-action: manipulation;
   -webkit-tap-highlight-color: transparent;
   user-select: none;
 }
 
 .gamegrid-dpad-btn {
+  flex: 1 1 0;
   min-width: 2.75rem;
+  max-width: 4.5rem;
   min-height: 2.75rem;
   font-size: 1.25rem;
   line-height: 1;
   padding: 0.35rem 0.5rem;
   box-sizing: border-box;
-  background-color: var(--gg-surface);
-  border: 2px solid var(--gg-accent);
-  color: var(--gg-accent);
+  background-color: #fff;
+  border: 1px solid #d1d5db;
+  color: #000;
 }
 
 .site-body--demo .gamegrid-dpad-btn:hover,
 .site-body--demo .gamegrid-dpad-btn:focus-visible,
 .site-body--demo .gamegrid-dpad-btn:active {
-  background-color: var(--gg-surface-hover);
-  border-color: var(--gg-accent-strong);
-  color: var(--gg-accent);
-}
-
-@media (max-width: 1199.98px) {
-  .gamegrid-dpad-btn {
-    min-width: 0;
-    min-height: 2.75rem;
-    padding: 0.25rem;
-    font-size: 1.15rem;
-  }
-
-  .gamegrid-dpad-btn--up {
-    grid-area: up;
-    justify-self: stretch;
-    width: 100%;
-  }
-
-  .gamegrid-dpad-btn--left {
-    grid-area: left;
-    align-self: stretch;
-    width: 100%;
-    height: 100%;
-  }
-
-  .gamegrid-dpad-btn--right {
-    grid-area: right;
-    align-self: stretch;
-    width: 100%;
-    height: 100%;
-  }
-
-  .gamegrid-dpad-btn--down {
-    grid-area: down;
-    justify-self: stretch;
-    width: 100%;
-  }
+  background-color: #f3f4f6;
+  border-color: #9ca3af;
+  color: #000;
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes mobile layout for all interactive demos (Coin Collector, Events, Big Maze, Mini Maze, Zoom Maze, Mobile Component).

**Layout:** On-screen arrow controls are now a single centered row **below** the grid (← ↑ → ↓), instead of surrounding the maze. This removes the side-padding / clipping issues on phones.

**Buttons:** White background with black arrow icons (light gray border; subtle gray hover).

## Changes

- `demo/src/partials/touchpad.hbs` — reorder buttons for horizontal row
- `demo/src/styles/styles.scss` — flex column wrap + flex row touch controls; remove surrounding grid layout

## Test plan

- [ ] Narrow viewport (&lt; 1200px): each demo shows grid then one row of four buttons below
- [ ] Buttons are white with black arrows, evenly spaced
- [ ] No horizontal shift or clipped controls on mobile
- [ ] Keyboard (WASD / arrows) still works at all sizes
- [ ] ≥ 1200px: on-screen controls hidden (`d-xl-none`)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3e4b83d3-1b05-4fe6-9709-ff4c505fc1bf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3e4b83d3-1b05-4fe6-9709-ff4c505fc1bf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

