### PR TITLE
Fix mobile demo layout and d-pad controls

### DIFF
--- a/demo/src/index.html
+++ b/demo/src/index.html
@@ -40,8 +40,8 @@
           </div>
         </div>
         <div class="col-12">
-          {{> coinmaze}} {{> events}} {{> bigmaze}} {{> minimaze}}
-          {{> zoommaze}} {{> mobilecomponent}}
+          {{> coinmaze}} {{> zoommaze}} {{> minimaze}}
+            {{> events}} {{> bigmaze}} {{> mobilecomponent}}
         </div>
       </div>
       <footer class="site-demo__footer">

--- a/demo/src/output.html
+++ b/demo/src/output.html
@@ -169,16 +169,16 @@
         >
           <button
             type='button'
-            class='btn gamegrid-dpad-btn gamegrid-dpad-btn--up'
-            data-gamegrid-move='up'
-            aria-label='Move up'
-          >↑</button>
-          <button
-            type='button'
             class='btn gamegrid-dpad-btn gamegrid-dpad-btn--left'
             data-gamegrid-move='left'
             aria-label='Move left'
           >←</button>
+          <button
+            type='button'
+            class='btn gamegrid-dpad-btn gamegrid-dpad-btn--up'
+            data-gamegrid-move='up'
+            aria-label='Move up'
+          >↑</button>
           <button
             type='button'
             class='btn gamegrid-dpad-btn gamegrid-dpad-btn--right'
@@ -208,16 +208,16 @@
         >
           <button
             type='button'
-            class='btn gamegrid-dpad-btn gamegrid-dpad-btn--up'
-            data-gamegrid-move='up'
-            aria-label='Move up'
-          >↑</button>
-          <button
-            type='button'
             class='btn gamegrid-dpad-btn gamegrid-dpad-btn--left'
             data-gamegrid-move='left'
             aria-label='Move left'
           >←</button>
+          <button
+            type='button'
+            class='btn gamegrid-dpad-btn gamegrid-dpad-btn--up'
+            data-gamegrid-move='up'
+            aria-label='Move up'
+          >↑</button>
           <button
             type='button'
             class='btn gamegrid-dpad-btn gamegrid-dpad-btn--right'
@@ -269,16 +269,16 @@
         >
           <button
             type='button'
-            class='btn gamegrid-dpad-btn gamegrid-dpad-btn--up'
-            data-gamegrid-move='up'
-            aria-label='Move up'
-          >↑</button>
-          <button
-            type='button'
             class='btn gamegrid-dpad-btn gamegrid-dpad-btn--left'
             data-gamegrid-move='left'
             aria-label='Move left'
           >←</button>
+          <button
+            type='button'
+            class='btn gamegrid-dpad-btn gamegrid-dpad-btn--up'
+            data-gamegrid-move='up'
+            aria-label='Move up'
+          >↑</button>
           <button
             type='button'
             class='btn gamegrid-dpad-btn gamegrid-dpad-btn--right'
@@ -325,16 +325,16 @@
         >
           <button
             type='button'
-            class='btn gamegrid-dpad-btn gamegrid-dpad-btn--up'
-            data-gamegrid-move='up'
-            aria-label='Move up'
-          >↑</button>
-          <button
-            type='button'
             class='btn gamegrid-dpad-btn gamegrid-dpad-btn--left'
             data-gamegrid-move='left'
             aria-label='Move left'
           >←</button>
+          <button
+            type='button'
+            class='btn gamegrid-dpad-btn gamegrid-dpad-btn--up'
+            data-gamegrid-move='up'
+            aria-label='Move up'
+          >↑</button>
           <button
             type='button'
             class='btn gamegrid-dpad-btn gamegrid-dpad-btn--right'
@@ -393,16 +393,16 @@
         >
           <button
             type='button'
-            class='btn gamegrid-dpad-btn gamegrid-dpad-btn--up'
-            data-gamegrid-move='up'
-            aria-label='Move up'
-          >↑</button>
-          <button
-            type='button'
             class='btn gamegrid-dpad-btn gamegrid-dpad-btn--left'
             data-gamegrid-move='left'
             aria-label='Move left'
           >←</button>
+          <button
+            type='button'
+            class='btn gamegrid-dpad-btn gamegrid-dpad-btn--up'
+            data-gamegrid-move='up'
+            aria-label='Move up'
+          >↑</button>
           <button
             type='button'
             class='btn gamegrid-dpad-btn gamegrid-dpad-btn--right'
@@ -443,16 +443,16 @@
         >
           <button
             type='button'
-            class='btn gamegrid-dpad-btn gamegrid-dpad-btn--up'
-            data-gamegrid-move='up'
-            aria-label='Move up'
-          >↑</button>
-          <button
-            type='button'
             class='btn gamegrid-dpad-btn gamegrid-dpad-btn--left'
             data-gamegrid-move='left'
             aria-label='Move left'
           >←</button>
+          <button
+            type='button'
+            class='btn gamegrid-dpad-btn gamegrid-dpad-btn--up'
+            data-gamegrid-move='up'
+            aria-label='Move up'
+          >↑</button>
           <button
             type='button'
             class='btn gamegrid-dpad-btn gamegrid-dpad-btn--right'

--- a/demo/src/output.html
+++ b/demo/src/output.html
@@ -70,10 +70,10 @@
           <button
             type='button'
             class='btn btn-outline-secondary text-start'
-            id='demo-nav-events'
-            data-demo-pane='demo-events'
+            id='demo-nav-zoommaze'
+            data-demo-pane='demo-zoommaze'
           >
-            With Events
+            Zoom Maze
           </button>
           <button
             type='button'
@@ -91,13 +91,14 @@
           >
             Mini Maze
           </button>
+       
           <button
             type='button'
             class='btn btn-outline-secondary text-start'
-            id='demo-nav-zoommaze'
-            data-demo-pane='demo-zoommaze'
+            id='demo-nav-events'
+            data-demo-pane='demo-events'
           >
-            Zoom Maze
+            With Events
           </button>
           <button
             type='button'
@@ -107,6 +108,7 @@
           >
             Mobile Component
           </button>
+    
         </nav>
       </div>
     </div>
@@ -196,7 +198,132 @@
     </div>
  
   </div>
-</div> <div class='demo-pane d-none' id='demo-events'>
+</div> <div class='demo-pane d-none' id='demo-zoommaze'>
+  <div class='row g-3 align-items-start'>
+    <div class='col-12 col-xl-7 order-2 order-xl-1'>
+      <h2>Zoom Maze</h2>
+      <p>
+        A 20×20 grid viewed through quadrant zoom (10×10 per region). Move to a zoom
+        edge to slide into the next region, or use the quadrant buttons.
+      </p>
+      <p class='mb-2'>
+        Current region:
+        <strong id='zoom-maze-region'>SE</strong>
+      </p>
+      <p class='small text-muted mb-2' id='zoom-maze-log'>Move with WASD, arrows, or the d-pad.</p>
+      <div class='form-check form-switch mb-3'>
+        <input
+          class='form-check-input'
+          type='checkbox'
+          role='switch'
+          id='zoom-maze-animate'
+          checked
+        />
+        <label class='form-check-label' for='zoom-maze-animate'>Animate zoom transitions</label>
+      </div>
+      <div class='d-flex flex-wrap gap-2 mb-3'>
+        <button type='button' class='btn btn-sm zoom-maze-quadrant-btn' id='zoom-maze-nw'>NW</button>
+        <button type='button' class='btn btn-sm zoom-maze-quadrant-btn' id='zoom-maze-ne'>NE</button>
+        <button type='button' class='btn btn-sm zoom-maze-quadrant-btn' id='zoom-maze-sw'>SW</button>
+        <button type='button' class='btn btn-sm zoom-maze-quadrant-btn' id='zoom-maze-se'>SE</button>
+        <button type='button' class='btn btn-sm btn-outline-danger' id='zoom-maze-clear'>Clear zoom</button>
+      </div>
+    </div>
+    <div class='col-12 col-xl-5 order-1 order-xl-2'>
+      <div class='demo-grid-wrap demo-grid-wrap--zoom mx-auto'>
+        <div class='demo-grid-mount' id='zoom-maze'></div>
+        <div
+          id='zoommaze-demo-dpad'
+          class='gamegrid-touch-controls d-xl-none'
+          aria-label='On-screen movement controls'
+        >
+          <button
+            type='button'
+            class='btn gamegrid-dpad-btn gamegrid-dpad-btn--left'
+            data-gamegrid-move='left'
+            aria-label='Move left'
+          >←</button>
+          <button
+            type='button'
+            class='btn gamegrid-dpad-btn gamegrid-dpad-btn--up'
+            data-gamegrid-move='up'
+            aria-label='Move up'
+          >↑</button>
+          <button
+            type='button'
+            class='btn gamegrid-dpad-btn gamegrid-dpad-btn--right'
+            data-gamegrid-move='right'
+            aria-label='Move right'
+          >→</button>
+          <button
+            type='button'
+            class='btn gamegrid-dpad-btn gamegrid-dpad-btn--down'
+            data-gamegrid-move='down'
+            aria-label='Move down'
+          >↓</button>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+ <div class='demo-pane d-none' id='demo-minimaze'>
+  <div class='row g-3 align-items-start'>
+    <div class='col-12 col-xl-7 order-2 order-xl-1'>
+      <h2>Mini Maze</h2>
+      <p>This maze is 10×10.</p>
+      <p>
+        Use WASD or Arrow Keys, or the on-screen directional pad on smaller
+        viewports, to travel around the maze.
+      </p>
+      <p>You can wrap on both the X and Y axis</p>
+      <p>
+        <strong>Note:</strong>
+        This map is randomly generated. If you are unable to complete the maze
+        please click the "Regenerate Maze" button
+      </p>
+
+      <button id='regenerate-maze3' class='btn btn-primary'>
+        Regenerate Maze
+      </button>
+    </div>
+    <div class='col-12 col-xl-5 order-1 order-xl-2'>
+      <div class='demo-grid-wrap mx-auto'>
+        <div class='demo-grid-mount' id='maze2'></div>
+        <div
+          id='minimaze-demo-dpad'
+          class='gamegrid-touch-controls d-xl-none'
+          aria-label='On-screen movement controls'
+        >
+          <button
+            type='button'
+            class='btn gamegrid-dpad-btn gamegrid-dpad-btn--left'
+            data-gamegrid-move='left'
+            aria-label='Move left'
+          >←</button>
+          <button
+            type='button'
+            class='btn gamegrid-dpad-btn gamegrid-dpad-btn--up'
+            data-gamegrid-move='up'
+            aria-label='Move up'
+          >↑</button>
+          <button
+            type='button'
+            class='btn gamegrid-dpad-btn gamegrid-dpad-btn--right'
+            data-gamegrid-move='right'
+            aria-label='Move right'
+          >→</button>
+          <button
+            type='button'
+            class='btn gamegrid-dpad-btn gamegrid-dpad-btn--down'
+            data-gamegrid-move='down'
+            aria-label='Move down'
+          >↓</button>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+            <div class='demo-pane d-none' id='demo-events'>
   <div class='row g-3'>
     <div class='col-12 col-lg-5 col-xl-4'>
       <div class='demo-grid-wrap mx-auto'>
@@ -295,132 +422,7 @@
       </div>
     </div>
   </div>
-</div> <div class='demo-pane d-none' id='demo-minimaze'>
-  <div class='row g-3 align-items-start'>
-    <div class='col-12 col-xl-7 order-2 order-xl-1'>
-      <h2>Mini Maze</h2>
-      <p>This maze is 10×10.</p>
-      <p>
-        Use WASD or Arrow Keys, or the on-screen directional pad on smaller
-        viewports, to travel around the maze.
-      </p>
-      <p>You can wrap on both the X and Y axis</p>
-      <p>
-        <strong>Note:</strong>
-        This map is randomly generated. If you are unable to complete the maze
-        please click the "Regenerate Maze" button
-      </p>
-
-      <button id='regenerate-maze3' class='btn btn-primary'>
-        Regenerate Maze
-      </button>
-    </div>
-    <div class='col-12 col-xl-5 order-1 order-xl-2'>
-      <div class='demo-grid-wrap mx-auto'>
-        <div class='demo-grid-mount' id='maze2'></div>
-        <div
-          id='minimaze-demo-dpad'
-          class='gamegrid-touch-controls d-xl-none'
-          aria-label='On-screen movement controls'
-        >
-          <button
-            type='button'
-            class='btn gamegrid-dpad-btn gamegrid-dpad-btn--left'
-            data-gamegrid-move='left'
-            aria-label='Move left'
-          >←</button>
-          <button
-            type='button'
-            class='btn gamegrid-dpad-btn gamegrid-dpad-btn--up'
-            data-gamegrid-move='up'
-            aria-label='Move up'
-          >↑</button>
-          <button
-            type='button'
-            class='btn gamegrid-dpad-btn gamegrid-dpad-btn--right'
-            data-gamegrid-move='right'
-            aria-label='Move right'
-          >→</button>
-          <button
-            type='button'
-            class='btn gamegrid-dpad-btn gamegrid-dpad-btn--down'
-            data-gamegrid-move='down'
-            aria-label='Move down'
-          >↓</button>
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
-          <div class='demo-pane d-none' id='demo-zoommaze'>
-  <div class='row g-3 align-items-start'>
-    <div class='col-12 col-xl-7 order-2 order-xl-1'>
-      <h2>Zoom Maze</h2>
-      <p>
-        A 20×20 grid viewed through quadrant zoom (10×10 per region). Move to a zoom
-        edge to slide into the next region, or use the quadrant buttons.
-      </p>
-      <p class='mb-2'>
-        Current region:
-        <strong id='zoom-maze-region'>SE</strong>
-      </p>
-      <p class='small text-muted mb-2' id='zoom-maze-log'>Move with WASD, arrows, or the d-pad.</p>
-      <div class='form-check form-switch mb-3'>
-        <input
-          class='form-check-input'
-          type='checkbox'
-          role='switch'
-          id='zoom-maze-animate'
-          checked
-        />
-        <label class='form-check-label' for='zoom-maze-animate'>Animate zoom transitions</label>
-      </div>
-      <div class='d-flex flex-wrap gap-2 mb-3'>
-        <button type='button' class='btn btn-sm zoom-maze-quadrant-btn' id='zoom-maze-nw'>NW</button>
-        <button type='button' class='btn btn-sm zoom-maze-quadrant-btn' id='zoom-maze-ne'>NE</button>
-        <button type='button' class='btn btn-sm zoom-maze-quadrant-btn' id='zoom-maze-sw'>SW</button>
-        <button type='button' class='btn btn-sm zoom-maze-quadrant-btn' id='zoom-maze-se'>SE</button>
-        <button type='button' class='btn btn-sm btn-outline-danger' id='zoom-maze-clear'>Clear zoom</button>
-      </div>
-    </div>
-    <div class='col-12 col-xl-5 order-1 order-xl-2'>
-      <div class='demo-grid-wrap demo-grid-wrap--zoom mx-auto'>
-        <div class='demo-grid-mount' id='zoom-maze'></div>
-        <div
-          id='zoommaze-demo-dpad'
-          class='gamegrid-touch-controls d-xl-none'
-          aria-label='On-screen movement controls'
-        >
-          <button
-            type='button'
-            class='btn gamegrid-dpad-btn gamegrid-dpad-btn--left'
-            data-gamegrid-move='left'
-            aria-label='Move left'
-          >←</button>
-          <button
-            type='button'
-            class='btn gamegrid-dpad-btn gamegrid-dpad-btn--up'
-            data-gamegrid-move='up'
-            aria-label='Move up'
-          >↑</button>
-          <button
-            type='button'
-            class='btn gamegrid-dpad-btn gamegrid-dpad-btn--right'
-            data-gamegrid-move='right'
-            aria-label='Move right'
-          >→</button>
-          <button
-            type='button'
-            class='btn gamegrid-dpad-btn gamegrid-dpad-btn--down'
-            data-gamegrid-move='down'
-            aria-label='Move down'
-          >↓</button>
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
- <div class='demo-pane d-none' id='demo-mobile'>
+</div> <div class='demo-pane d-none' id='demo-mobile'>
   <div class='row g-3 align-items-start'>
     <div class='col-12 col-xl-7 order-2 order-xl-1'>
       <h2>Mobile Component</h2>

--- a/demo/src/output.html
+++ b/demo/src/output.html
@@ -169,25 +169,25 @@
         >
           <button
             type='button'
-            class='btn btn-outline-primary gamegrid-dpad-btn gamegrid-dpad-btn--up'
+            class='btn gamegrid-dpad-btn gamegrid-dpad-btn--up'
             data-gamegrid-move='up'
             aria-label='Move up'
           >↑</button>
           <button
             type='button'
-            class='btn btn-outline-primary gamegrid-dpad-btn gamegrid-dpad-btn--left'
+            class='btn gamegrid-dpad-btn gamegrid-dpad-btn--left'
             data-gamegrid-move='left'
             aria-label='Move left'
           >←</button>
           <button
             type='button'
-            class='btn btn-outline-primary gamegrid-dpad-btn gamegrid-dpad-btn--right'
+            class='btn gamegrid-dpad-btn gamegrid-dpad-btn--right'
             data-gamegrid-move='right'
             aria-label='Move right'
           >→</button>
           <button
             type='button'
-            class='btn btn-outline-primary gamegrid-dpad-btn gamegrid-dpad-btn--down'
+            class='btn gamegrid-dpad-btn gamegrid-dpad-btn--down'
             data-gamegrid-move='down'
             aria-label='Move down'
           >↓</button>
@@ -208,25 +208,25 @@
         >
           <button
             type='button'
-            class='btn btn-outline-primary gamegrid-dpad-btn gamegrid-dpad-btn--up'
+            class='btn gamegrid-dpad-btn gamegrid-dpad-btn--up'
             data-gamegrid-move='up'
             aria-label='Move up'
           >↑</button>
           <button
             type='button'
-            class='btn btn-outline-primary gamegrid-dpad-btn gamegrid-dpad-btn--left'
+            class='btn gamegrid-dpad-btn gamegrid-dpad-btn--left'
             data-gamegrid-move='left'
             aria-label='Move left'
           >←</button>
           <button
             type='button'
-            class='btn btn-outline-primary gamegrid-dpad-btn gamegrid-dpad-btn--right'
+            class='btn gamegrid-dpad-btn gamegrid-dpad-btn--right'
             data-gamegrid-move='right'
             aria-label='Move right'
           >→</button>
           <button
             type='button'
-            class='btn btn-outline-primary gamegrid-dpad-btn gamegrid-dpad-btn--down'
+            class='btn gamegrid-dpad-btn gamegrid-dpad-btn--down'
             data-gamegrid-move='down'
             aria-label='Move down'
           >↓</button>
@@ -269,25 +269,25 @@
         >
           <button
             type='button'
-            class='btn btn-outline-primary gamegrid-dpad-btn gamegrid-dpad-btn--up'
+            class='btn gamegrid-dpad-btn gamegrid-dpad-btn--up'
             data-gamegrid-move='up'
             aria-label='Move up'
           >↑</button>
           <button
             type='button'
-            class='btn btn-outline-primary gamegrid-dpad-btn gamegrid-dpad-btn--left'
+            class='btn gamegrid-dpad-btn gamegrid-dpad-btn--left'
             data-gamegrid-move='left'
             aria-label='Move left'
           >←</button>
           <button
             type='button'
-            class='btn btn-outline-primary gamegrid-dpad-btn gamegrid-dpad-btn--right'
+            class='btn gamegrid-dpad-btn gamegrid-dpad-btn--right'
             data-gamegrid-move='right'
             aria-label='Move right'
           >→</button>
           <button
             type='button'
-            class='btn btn-outline-primary gamegrid-dpad-btn gamegrid-dpad-btn--down'
+            class='btn gamegrid-dpad-btn gamegrid-dpad-btn--down'
             data-gamegrid-move='down'
             aria-label='Move down'
           >↓</button>
@@ -325,25 +325,25 @@
         >
           <button
             type='button'
-            class='btn btn-outline-primary gamegrid-dpad-btn gamegrid-dpad-btn--up'
+            class='btn gamegrid-dpad-btn gamegrid-dpad-btn--up'
             data-gamegrid-move='up'
             aria-label='Move up'
           >↑</button>
           <button
             type='button'
-            class='btn btn-outline-primary gamegrid-dpad-btn gamegrid-dpad-btn--left'
+            class='btn gamegrid-dpad-btn gamegrid-dpad-btn--left'
             data-gamegrid-move='left'
             aria-label='Move left'
           >←</button>
           <button
             type='button'
-            class='btn btn-outline-primary gamegrid-dpad-btn gamegrid-dpad-btn--right'
+            class='btn gamegrid-dpad-btn gamegrid-dpad-btn--right'
             data-gamegrid-move='right'
             aria-label='Move right'
           >→</button>
           <button
             type='button'
-            class='btn btn-outline-primary gamegrid-dpad-btn gamegrid-dpad-btn--down'
+            class='btn gamegrid-dpad-btn gamegrid-dpad-btn--down'
             data-gamegrid-move='down'
             aria-label='Move down'
           >↓</button>
@@ -393,25 +393,25 @@
         >
           <button
             type='button'
-            class='btn btn-outline-primary gamegrid-dpad-btn gamegrid-dpad-btn--up'
+            class='btn gamegrid-dpad-btn gamegrid-dpad-btn--up'
             data-gamegrid-move='up'
             aria-label='Move up'
           >↑</button>
           <button
             type='button'
-            class='btn btn-outline-primary gamegrid-dpad-btn gamegrid-dpad-btn--left'
+            class='btn gamegrid-dpad-btn gamegrid-dpad-btn--left'
             data-gamegrid-move='left'
             aria-label='Move left'
           >←</button>
           <button
             type='button'
-            class='btn btn-outline-primary gamegrid-dpad-btn gamegrid-dpad-btn--right'
+            class='btn gamegrid-dpad-btn gamegrid-dpad-btn--right'
             data-gamegrid-move='right'
             aria-label='Move right'
           >→</button>
           <button
             type='button'
-            class='btn btn-outline-primary gamegrid-dpad-btn gamegrid-dpad-btn--down'
+            class='btn gamegrid-dpad-btn gamegrid-dpad-btn--down'
             data-gamegrid-move='down'
             aria-label='Move down'
           >↓</button>
@@ -443,25 +443,25 @@
         >
           <button
             type='button'
-            class='btn btn-outline-primary gamegrid-dpad-btn gamegrid-dpad-btn--up'
+            class='btn gamegrid-dpad-btn gamegrid-dpad-btn--up'
             data-gamegrid-move='up'
             aria-label='Move up'
           >↑</button>
           <button
             type='button'
-            class='btn btn-outline-primary gamegrid-dpad-btn gamegrid-dpad-btn--left'
+            class='btn gamegrid-dpad-btn gamegrid-dpad-btn--left'
             data-gamegrid-move='left'
             aria-label='Move left'
           >←</button>
           <button
             type='button'
-            class='btn btn-outline-primary gamegrid-dpad-btn gamegrid-dpad-btn--right'
+            class='btn gamegrid-dpad-btn gamegrid-dpad-btn--right'
             data-gamegrid-move='right'
             aria-label='Move right'
           >→</button>
           <button
             type='button'
-            class='btn btn-outline-primary gamegrid-dpad-btn gamegrid-dpad-btn--down'
+            class='btn gamegrid-dpad-btn gamegrid-dpad-btn--down'
             data-gamegrid-move='down'
             aria-label='Move down'
           >↓</button>

--- a/demo/src/partials/offcanvas-demolist.hbs
+++ b/demo/src/partials/offcanvas-demolist.hbs
@@ -32,10 +32,10 @@
       <button
         type='button'
         class='btn btn-outline-secondary text-start'
-        id='demo-nav-events'
-        data-demo-pane='demo-events'
+        id='demo-nav-zoommaze'
+        data-demo-pane='demo-zoommaze'
       >
-        With Events
+        Zoom Maze
       </button>
       <button
         type='button'
@@ -53,13 +53,14 @@
       >
         Mini Maze
       </button>
+   
       <button
         type='button'
         class='btn btn-outline-secondary text-start'
-        id='demo-nav-zoommaze'
-        data-demo-pane='demo-zoommaze'
+        id='demo-nav-events'
+        data-demo-pane='demo-events'
       >
-        Zoom Maze
+        With Events
       </button>
       <button
         type='button'
@@ -69,6 +70,7 @@
       >
         Mobile Component
       </button>
+
     </nav>
   </div>
 </div>

--- a/demo/src/partials/touchpad.hbs
+++ b/demo/src/partials/touchpad.hbs
@@ -5,16 +5,16 @@
 >
   <button
     type='button'
-    class='btn gamegrid-dpad-btn gamegrid-dpad-btn--up'
-    data-gamegrid-move='up'
-    aria-label='Move up'
-  >↑</button>
-  <button
-    type='button'
     class='btn gamegrid-dpad-btn gamegrid-dpad-btn--left'
     data-gamegrid-move='left'
     aria-label='Move left'
   >←</button>
+  <button
+    type='button'
+    class='btn gamegrid-dpad-btn gamegrid-dpad-btn--up'
+    data-gamegrid-move='up'
+    aria-label='Move up'
+  >↑</button>
   <button
     type='button'
     class='btn gamegrid-dpad-btn gamegrid-dpad-btn--right'

--- a/demo/src/partials/touchpad.hbs
+++ b/demo/src/partials/touchpad.hbs
@@ -5,25 +5,25 @@
 >
   <button
     type='button'
-    class='btn btn-outline-primary gamegrid-dpad-btn gamegrid-dpad-btn--up'
+    class='btn gamegrid-dpad-btn gamegrid-dpad-btn--up'
     data-gamegrid-move='up'
     aria-label='Move up'
   >↑</button>
   <button
     type='button'
-    class='btn btn-outline-primary gamegrid-dpad-btn gamegrid-dpad-btn--left'
+    class='btn gamegrid-dpad-btn gamegrid-dpad-btn--left'
     data-gamegrid-move='left'
     aria-label='Move left'
   >←</button>
   <button
     type='button'
-    class='btn btn-outline-primary gamegrid-dpad-btn gamegrid-dpad-btn--right'
+    class='btn gamegrid-dpad-btn gamegrid-dpad-btn--right'
     data-gamegrid-move='right'
     aria-label='Move right'
   >→</button>
   <button
     type='button'
-    class='btn btn-outline-primary gamegrid-dpad-btn gamegrid-dpad-btn--down'
+    class='btn gamegrid-dpad-btn gamegrid-dpad-btn--down'
     data-gamegrid-move='down'
     aria-label='Move down'
   >↓</button>

--- a/demo/src/styles/styles.scss
+++ b/demo/src/styles/styles.scss
@@ -319,44 +319,44 @@
   overflow: auto;
 }
 
-/* Mobile: grid 99vw with 7vw side controls; break out of container padding */
+/* Mobile / tablet: dpad around grid within the column (no viewport breakout) */
 @media (max-width: 1199.98px) {
   .demo-grid-wrap {
     display: grid;
-    grid-template-columns: 7vw 85vw 7vw;
+    grid-template-columns: minmax(2.75rem, 12%) 1fr minmax(2.75rem, 12%);
     grid-template-rows: auto minmax(0, 1fr) auto;
     grid-template-areas:
       '. up .'
       'left grid right'
       '. down .';
-    gap: 0;
+    gap: 0.25rem;
     align-items: stretch;
     justify-items: stretch;
-    width: 99vw;
-    max-width: 99vw;
-    margin-left: calc(50% - 49.5vw);
-    margin-right: calc(50% - 49.5vw);
+    width: 100%;
+    max-width: 100%;
+    margin-left: 0;
+    margin-right: 0;
     overflow: visible;
   }
 
   .demo-grid-wrap--tall {
-    width: 99vw;
-    max-width: 99vw;
+    width: 100%;
+    max-width: 100%;
     max-height: none;
     overflow: visible;
   }
 
   .demo-grid-wrap--zoom {
-    width: 99vw;
-    max-width: 99vw;
+    width: 100%;
+    max-width: 100%;
     max-height: none;
     overflow: visible;
   }
 
   .demo-grid-wrap > .demo-grid-mount {
     grid-area: grid;
-    width: 85vw;
-    max-width: 85vw;
+    width: 100%;
+    max-width: 100%;
     min-width: 0;
     min-height: 0;
     overflow: auto;
@@ -364,11 +364,11 @@
   }
 
   .demo-grid-wrap--tall > .demo-grid-mount {
-    max-height: min(70vh, 85vw);
+    max-height: min(70vh, 100%);
   }
 
   .demo-grid-wrap--zoom > .demo-grid-mount {
-    max-height: min(55vh, 85vw);
+    max-height: min(55vh, 100%);
   }
 
   .demo-grid-wrap .gamegrid-touch-controls {
@@ -444,6 +444,18 @@ $zoom-quadrant-se: #f9a8d4;
   font-size: 1.25rem;
   line-height: 1;
   padding: 0.35rem 0.5rem;
+  box-sizing: border-box;
+  background-color: var(--gg-surface);
+  border: 2px solid var(--gg-accent);
+  color: var(--gg-accent);
+}
+
+.site-body--demo .gamegrid-dpad-btn:hover,
+.site-body--demo .gamegrid-dpad-btn:focus-visible,
+.site-body--demo .gamegrid-dpad-btn:active {
+  background-color: var(--gg-surface-hover);
+  border-color: var(--gg-accent-strong);
+  color: var(--gg-accent);
 }
 
 @media (max-width: 1199.98px) {
@@ -457,30 +469,26 @@ $zoom-quadrant-se: #f9a8d4;
   .gamegrid-dpad-btn--up {
     grid-area: up;
     justify-self: stretch;
-    width: 85vw;
-    max-width: 85vw;
+    width: 100%;
   }
 
   .gamegrid-dpad-btn--left {
     grid-area: left;
     align-self: stretch;
-    width: 7vw;
-    max-width: 7vw;
+    width: 100%;
     height: 100%;
   }
 
   .gamegrid-dpad-btn--right {
     grid-area: right;
     align-self: stretch;
-    width: 7vw;
-    max-width: 7vw;
+    width: 100%;
     height: 100%;
   }
 
   .gamegrid-dpad-btn--down {
     grid-area: down;
     justify-self: stretch;
-    width: 85vw;
-    max-width: 85vw;
+    width: 100%;
   }
 }

--- a/demo/src/styles/styles.scss
+++ b/demo/src/styles/styles.scss
@@ -441,3 +441,10 @@ $zoom-quadrant-se: #f9a8d4;
   border-color: #9ca3af;
   color: #000;
 }
+
+.btn.gamegrid-dpad-btn {
+  background-color: #fff;
+  border: 1px solid #d1d5db;
+  color: #000;
+  font-size: 1.5rem;
+}

--- a/demo/src/styles/styles.scss
+++ b/demo/src/styles/styles.scss
@@ -301,6 +301,9 @@
 
 /* Grids stay within the viewport; inner cells remain %-based */
 .demo-grid-wrap {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
   width: 100%;
   max-width: min(100%, 520px);
   overflow-x: auto;
@@ -319,48 +322,20 @@
   overflow: auto;
 }
 
-/* Mobile / tablet: dpad around grid within the column (no viewport breakout) */
 @media (max-width: 1199.98px) {
   .demo-grid-wrap {
-    display: grid;
-    grid-template-columns: minmax(2.75rem, 12%) 1fr minmax(2.75rem, 12%);
-    grid-template-rows: auto minmax(0, 1fr) auto;
-    grid-template-areas:
-      '. up .'
-      'left grid right'
-      '. down .';
-    gap: 0.25rem;
-    align-items: stretch;
-    justify-items: stretch;
     width: 100%;
     max-width: 100%;
-    margin-left: 0;
-    margin-right: 0;
-    overflow: visible;
   }
 
   .demo-grid-wrap--tall {
-    width: 100%;
     max-width: 100%;
     max-height: none;
-    overflow: visible;
   }
 
   .demo-grid-wrap--zoom {
-    width: 100%;
     max-width: 100%;
     max-height: none;
-    overflow: visible;
-  }
-
-  .demo-grid-wrap > .demo-grid-mount {
-    grid-area: grid;
-    width: 100%;
-    max-width: 100%;
-    min-width: 0;
-    min-height: 0;
-    overflow: auto;
-    -webkit-overflow-scrolling: touch;
   }
 
   .demo-grid-wrap--tall > .demo-grid-mount {
@@ -369,10 +344,6 @@
 
   .demo-grid-wrap--zoom > .demo-grid-mount {
     max-height: min(55vh, 100%);
-  }
-
-  .demo-grid-wrap .gamegrid-touch-controls {
-    display: contents;
   }
 }
 
@@ -432,63 +403,41 @@ $zoom-quadrant-se: #f9a8d4;
   min-width: 0;
 }
 
+.demo-grid-mount {
+  min-width: 0;
+  width: 100%;
+}
+
 .gamegrid-touch-controls {
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  align-items: center;
+  gap: 0.5rem;
+  margin-top: 0.75rem;
   touch-action: manipulation;
   -webkit-tap-highlight-color: transparent;
   user-select: none;
 }
 
 .gamegrid-dpad-btn {
+  flex: 1 1 0;
   min-width: 2.75rem;
+  max-width: 4.5rem;
   min-height: 2.75rem;
   font-size: 1.25rem;
   line-height: 1;
   padding: 0.35rem 0.5rem;
   box-sizing: border-box;
-  background-color: var(--gg-surface);
-  border: 2px solid var(--gg-accent);
-  color: var(--gg-accent);
+  background-color: #fff;
+  border: 1px solid #d1d5db;
+  color: #000;
 }
 
 .site-body--demo .gamegrid-dpad-btn:hover,
 .site-body--demo .gamegrid-dpad-btn:focus-visible,
 .site-body--demo .gamegrid-dpad-btn:active {
-  background-color: var(--gg-surface-hover);
-  border-color: var(--gg-accent-strong);
-  color: var(--gg-accent);
-}
-
-@media (max-width: 1199.98px) {
-  .gamegrid-dpad-btn {
-    min-width: 0;
-    min-height: 2.75rem;
-    padding: 0.25rem;
-    font-size: 1.15rem;
-  }
-
-  .gamegrid-dpad-btn--up {
-    grid-area: up;
-    justify-self: stretch;
-    width: 100%;
-  }
-
-  .gamegrid-dpad-btn--left {
-    grid-area: left;
-    align-self: stretch;
-    width: 100%;
-    height: 100%;
-  }
-
-  .gamegrid-dpad-btn--right {
-    grid-area: right;
-    align-self: stretch;
-    width: 100%;
-    height: 100%;
-  }
-
-  .gamegrid-dpad-btn--down {
-    grid-area: down;
-    justify-self: stretch;
-    width: 100%;
-  }
+  background-color: #f3f4f6;
+  border-color: #9ca3af;
+  color: #000;
 }


### PR DESCRIPTION
## Summary
- Center the mobile maze/grid in the column width instead of breaking out with a 99vw layout that clipped on small viewports
- Move all demo touch controls into a single centered row under the grid (no wrap-around placement)
- Restyle d-pad buttons with solid white fill and black arrows for clearer mobile affordance

## Test plan
- [ ] Open the demo on a phone-width viewport (or DevTools mobile emulation)
- [ ] Confirm the maze stays centered with no horizontal clipping/overflow
- [ ] Confirm the d-pad sits in one row below the grid and buttons are clearly visible
- [ ] Spot-check a couple of demos from the offcanvas list for the same layout


Made with [Cursor](https://cursor.com)